### PR TITLE
Add lint tools to main requirements and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+# sumoracle
+
+This Django project interacts with the sumo-api.
+
+## Development Setup
+
+Install all requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Linting and Formatting
+
+Run ruff to check code style and `isort` to sort imports.
+
+```bash
+ruff .
+isort .
+```
+
+To automatically fix issues with ruff, run:
+
+```bash
+ruff --fix .
+```
+
+You can also format the project using Ruff's formatter:
+
+```bash
+ruff format .
+```
 # Sumoracle
 
 This project uses Django. Unit tests are located in the `tests` application.

--- a/app/management/commands/populate.py
+++ b/app/management/commands/populate.py
@@ -6,9 +6,9 @@ from asgiref.sync import sync_to_async
 from django.core.management.base import BaseCommand
 
 from app.constants import DIVISION_LEVELS
-from app.models.rikishi import Heya, Rikishi, Shusshin
 from app.models.division import Division
 from app.models.rank import Rank
+from app.models.rikishi import Heya, Rikishi, Shusshin
 from libs.sumoapi import SumoApiClient
 
 

--- a/app/management/commands/ranking.py
+++ b/app/management/commands/ranking.py
@@ -7,10 +7,10 @@ from asgiref.sync import sync_to_async
 from django.core.management.base import BaseCommand
 from django.utils.text import slugify
 
-from app.models.history import RankingHistory
-from app.models.rikishi import Rikishi
 from app.models.basho import Basho
+from app.models.history import RankingHistory
 from app.models.rank import Rank
+from app.models.rikishi import Rikishi
 from libs.sumoapi import SumoApiClient
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,4 @@
+from .basho import Basho  # noqa: F401
 from .division import Division  # noqa: F401
 from .rank import Rank  # noqa: F401
-from .basho import Basho  # noqa: F401
 from .rikishi import Heya, Rikishi, Shusshin  # noqa: F401

--- a/app/models/history.py
+++ b/app/models/history.py
@@ -1,8 +1,8 @@
 from django.db import models
 
-from .rikishi import Rikishi
 from .basho import Basho
 from .rank import Rank
+from .rikishi import Rikishi
 
 
 class BashoHistory(models.Model):

--- a/app/models/rank.py
+++ b/app/models/rank.py
@@ -1,11 +1,7 @@
 from django.db import models
 
-from app.constants import (
-    DIRECTION_NAMES,
-    DIRECTION_NAMES_SHORT,
-    RANK_NAMES,
-    RANK_NAMES_SHORT,
-)
+from app.constants import (DIRECTION_NAMES, DIRECTION_NAMES_SHORT, RANK_NAMES,
+                           RANK_NAMES_SHORT)
 
 from .division import Division
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@ h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
 idna==3.10
+isort==6.0.1
 pycountry==24.6.1
 requests==2.32.3
+ruff==0.11.13
 sniffio==1.3.1
 sqlparse==0.5.3
 urllib3==2.4.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 80


### PR DESCRIPTION
## Summary
- move ruff and isort to the main requirements file
- document Ruff formatter usage in README
- clean up import sorting across the project

## Testing
- `ruff check .`
- `isort --check-only .`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68436ea0d5548329a1d3ec7db1b61034