### PR TITLE
Add coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run ruff
         run: ruff check .
-      - name: Run tests
-        run: python manage.py test
+      - name: Run tests with coverage
+        run: |
+          coverage run manage.py test
+          coverage report --fail-under=80

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ anyio==4.9.0
 asgiref==3.8.1
 certifi==2025.4.26
 cfgv==3.4.0
+coverage==7.8.2
 charset-normalizer==3.4.2
 distlib==0.3.9
 Django==5.2.1


### PR DESCRIPTION
## Summary
- record test coverage in CI and require minimum coverage
- install `coverage` package for test runs

## Testing
- `ruff check .`
- `coverage run manage.py test && coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_68437971df8083299a449176481aa34d