### PR TITLE
Add pip caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- cache pip in CI pipeline using actions/cache

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .` *(reverted unrelated formatting changes)*
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files` *(fails: files were modified by hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6843847f913c832994c961e0b44df238