### PR TITLE
Add admin permission test

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,15 @@
+from django.contrib.admin.sites import AdminSite
+from django.test import SimpleTestCase
+
+from app.admin.division import DivisionAdmin
+from app.models.division import Division
+
+
+class DivisionAdminPermissionTests(SimpleTestCase):
+    def setUp(self):
+        self.admin = DivisionAdmin(Division, AdminSite())
+
+    def test_no_permissions(self):
+        self.assertFalse(self.admin.has_add_permission(None))
+        self.assertFalse(self.admin.has_change_permission(None))
+        self.assertFalse(self.admin.has_delete_permission(None))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+from importlib import reload
+
+from django.test import SimpleTestCase
+
+import config.asgi
+import config.wsgi
+
+
+class ConfigModuleTests(SimpleTestCase):
+    def test_asgi_wsgi_import(self):
+        reload(config.asgi)
+        reload(config.wsgi)
+        self.assertIsNotNone(config.asgi.application)
+        self.assertIsNotNone(config.wsgi.application)

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from app.models.basho import Basho
+from app.models.division import Division
+from app.models.rank import Rank
+from app.models.rikishi import Heya, Rikishi, Shusshin
+
+
+class ModelUtilityTests(SimpleTestCase):
+    def test_basho_methods(self):
+        basho = Basho(year=2025, month=1)
+        self.assertEqual(basho.name(), "Hastu")
+        self.assertEqual(str(basho), "Hastu 2025")
+
+    def test_rank_methods(self):
+        division = Division(name="Makuuchi", name_short="M", level=1)
+        rank = Rank(
+            division=division,
+            title="Yokozuna",
+            level=1,
+            order=1,
+            direction="East",
+        )
+        self.assertEqual(str(rank), rank.name())
+        self.assertEqual(rank.name(), "Yokozuna 1E")
+        self.assertEqual(rank.long_name(), "Yokozuna 1 East")
+        self.assertEqual(rank.short_name(), "Y1E")
+
+        rank_no_order = Rank(
+            division=division,
+            title="Ozeki",
+            level=2,
+        )
+        self.assertEqual(rank_no_order.name(), "Ozeki")
+        self.assertEqual(rank_no_order.long_name(), "Ozeki")
+        self.assertEqual(rank_no_order.short_name(), "O")
+
+    def test_heya_shusshin_and_rikishi(self):
+        heya = Heya(name="TestBeya")
+        with patch("django.db.models.Model.save") as mock_save:
+            heya.save()
+            mock_save.assert_called_once()
+        self.assertEqual(heya.slug, "testbeya")
+        self.assertEqual(str(heya), "TestBeya")
+
+        shusshin = Shusshin(name="Tokyo")
+        with patch("django.db.models.Model.save") as mock_save:
+            shusshin.save()
+            mock_save.assert_called_once()
+        self.assertEqual(shusshin.slug, "tokyo")
+        self.assertEqual(shusshin.flag(), "🇯🇵")
+        shusshin.international = True
+        with patch("pycountry.countries.lookup") as lookup:
+            lookup.return_value = SimpleNamespace(flag="🇺🇸")
+            self.assertEqual(shusshin.flag(), "🇺🇸")
+            self.assertTrue(str(shusshin).startswith("🇺"))
+
+        rikishi = Rikishi(name="Hakuho", name_jp="白鵬")
+        self.assertEqual(str(rikishi), "Hakuho")
+
+    def test_import_history_module(self):
+        from app import models  # noqa: F401
+        from app.models import history as mod
+
+        self.assertTrue(hasattr(mod, "BashoHistory"))

--- a/tests/test_sumoapi.py
+++ b/tests/test_sumoapi.py
@@ -1,0 +1,116 @@
+import asyncio
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from libs.sumoapi import SumoApiClient
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.closed = False
+
+    async def get(self, *args, **kwargs):
+        return self.responses.pop(0)
+
+    async def aclose(self):
+        self.closed = True
+
+
+async def dummy_gather(*coros):
+    return [await c for c in coros]
+
+
+class SumoApiClientTests(SimpleTestCase):
+    def run_async(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_client_methods(self):
+        responses = [
+            DummyResponse({"records": [1]}),
+            DummyResponse({"records": []}),
+            DummyResponse({"r": 1}),
+            DummyResponse({"id": 1}),
+            DummyResponse({"stats": []}),
+            DummyResponse({"matches": []}),
+            DummyResponse({"matches": []}),
+            DummyResponse({"history": 1}),
+            DummyResponse({"history": 2}),
+            DummyResponse({"ranks": []}),
+            DummyResponse({"meas": 1}),
+            DummyResponse({"meas": 2}),
+            DummyResponse({"kimarite": []}),
+            DummyResponse({"kimarite": "x"}),
+            DummyResponse({"measurements": []}),
+            DummyResponse({"date": "x"}),
+            DummyResponse({"banzuke": []}),
+            DummyResponse({"torikumi": []}),
+            DummyResponse({"shikonas": []}),
+        ]
+        dummy_client = DummyClient(responses)
+        with (
+            patch("libs.sumoapi.httpx.AsyncClient", return_value=dummy_client),
+            patch("libs.sumoapi.asyncio.gather", new=dummy_gather),
+        ):
+            api = SumoApiClient()
+            self.run_async(api.__aenter__())
+            self.assertEqual(self.run_async(api.get_all_rikishi()), [1])
+            self.assertEqual(self.run_async(api.get_rikishis()), {"r": 1})
+            self.assertEqual(self.run_async(api.get_rikishi(1)), {"id": 1})
+            self.assertEqual(
+                self.run_async(api.get_rikishi_stats(1)), {"stats": []}
+            )
+            self.assertEqual(
+                self.run_async(api.get_rikishi_matches(1)), {"matches": []}
+            )
+            self.assertEqual(
+                self.run_async(api.get_rikishi_matches(1, 2)),
+                {"matches": []},
+            )
+            self.assertEqual(
+                self.run_async(api.get_ranking_history([1, 2])),
+                {1: {"history": 1}, 2: {"history": 2}},
+            )
+            self.assertEqual(self.run_async(api.get_ranks()), {"ranks": []})
+            self.assertEqual(
+                self.run_async(api.get_measurements_history([1, 2])),
+                {1: {"meas": 1}, 2: {"meas": 2}},
+            )
+            self.assertEqual(
+                self.run_async(api.get_kimarite_list()), {"kimarite": []}
+            )
+            self.assertEqual(
+                self.run_async(api.get_kimarite("y")), {"kimarite": "x"}
+            )
+            self.assertEqual(
+                self.run_async(api.get_measurements()), {"measurements": []}
+            )
+            self.assertEqual(
+                self.run_async(api.get_basho_by_id(1)), {"date": "x"}
+            )
+            self.assertEqual(
+                self.run_async(api.get_basho_banzuke(1, "makuuchi")),
+                {"banzuke": []},
+            )
+            self.assertEqual(
+                self.run_async(api.get_basho_torikumi(1, "makuuchi", 1)),
+                {"torikumi": []},
+            )
+            self.assertEqual(
+                self.run_async(api.get_shikonas()), {"shikonas": []}
+            )
+            self.run_async(api.__aexit__(None, None, None))
+            self.assertTrue(dummy_client.closed)


### PR DESCRIPTION
## Summary
- test Division admin permissions to restore 100% coverage for the admin module
- add tests for ASGI/WSGI modules
- add extra model tests
- add comprehensive Sumo API client tests

## Testing
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6848657f364483299d96d24b4eee19a2