### PR TITLE
Update docs for Python version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Autonomously fix or extend the codebase without violating the axioms.
 - Django application. Async commands and HTTP client in `libs/sumoapi.py`.
 - Tests live in `tests/`.
 - Ruff and isort handle linting and formatting.
+- Requires Python 3.12 or later.
 
 ## CLI First
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ basho and other sumo related objects.
 
 ## Project setup
 
+This project requires **Python 3.12** or later.
+
 1. Create and activate a virtual environment (optional but recommended):
    ```bash
    python -m venv .venv


### PR DESCRIPTION
## Summary
- document Python 3.12 requirement in README
- mention the minimum Python version in AGENTS notes

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68486c3cce8c8329b9900ca2978a0406