### PR TITLE
Add coverage threshold note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ of sync.
    coverage run manage.py test
    coverage report -m
    ```
+   Coverage must be at least 95%, matching `fail_under` in `pyproject.toml`.
 3. **Run pre-commit hooks** (if installed)
    ```bash
    pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To run the test suite with coverage enabled and print a summary:
 coverage run manage.py test
 coverage report -m
 ```
+Coverage must be at least 95%, matching the `fail_under` setting in `pyproject.toml`.
 Open `htmlcov/index.html` in a browser to inspect the report.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- document 95% coverage requirement in README
- note 95% coverage threshold in AGENTS workflow

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68486e52243483299526bda1336b3f65