### PR TITLE
Fix model name back to BashoHistory

### DIFF
--- a/app/management/commands/ranking.py
+++ b/app/management/commands/ranking.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.utils.text import slugify
 
 from app.models.basho import Basho
-from app.models.history import RankingHistory
+from app.models.history import BashoHistory
 from app.models.rank import Rank
 from app.models.rikishi import Rikishi
 from libs.sumoapi import SumoApiClient
@@ -31,7 +31,7 @@ def get_existing_rank():
 
 @sync_to_async
 def get_existing_keys():
-    return set(RankingHistory.objects.values_list("rikishi_id", "basho__slug"))
+    return set(BashoHistory.objects.values_list("rikishi_id", "basho__slug"))
 
 
 class Command(BaseCommand):
@@ -98,7 +98,7 @@ class Command(BaseCommand):
                     )
 
                     ranking_history_to_create.append(
-                        RankingHistory(rikishi=rikishi, basho=basho, rank=rank)
+                        BashoHistory(rikishi=rikishi, basho=basho, rank=rank)
                     )
 
             if len(ranking_history_to_create) >= 1000:
@@ -150,5 +150,5 @@ class Command(BaseCommand):
         return rank
 
     async def bulk_save(self, objs):
-        self.log(f"Inserting {len(objs)} RankingHistory objects...")
-        await RankingHistory.objects.abulk_create(objs, batch_size=500)
+        self.log(f"Inserting {len(objs)} BashoHistory objects...")
+        await BashoHistory.objects.abulk_create(objs, batch_size=500)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .basho import Basho  # noqa: F401
 from .division import Division  # noqa: F401
+from .history import BashoHistory  # noqa: F401
 from .rank import Rank  # noqa: F401
 from .rikishi import Heya, Rikishi, Shusshin  # noqa: F401


### PR DESCRIPTION
## Summary
- revert model rename to BashoHistory
- update exports and management command imports
- adjust unit tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68486fd52b10832982dc2c3cdf8af89e