### PR TITLE
Add slug auto-generation to Basho

### DIFF
--- a/app/models/basho.py
+++ b/app/models/basho.py
@@ -25,6 +25,11 @@ class Basho(models.Model):
     start_date = models.DateField(blank=True, null=True)
     end_date = models.DateField(blank=True, null=True)
 
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = f"{self.year}{self.month:02d}"
+        super().save(*args, **kwargs)
+
     def name(self):
         return BASHO_NAMES[self.month]
 

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -15,6 +15,13 @@ class ModelUtilityTests(SimpleTestCase):
         self.assertEqual(basho.name(), "Hastu")
         self.assertEqual(str(basho), "Hastu 2025")
 
+    def test_basho_slug_generation(self):
+        basho = Basho(year=2025, month=3)
+        with patch("django.db.models.Model.save") as mock_save:
+            basho.save()
+            mock_save.assert_called_once()
+        self.assertEqual(basho.slug, "202503")
+
     def test_rank_methods(self):
         division = Division(name="Makuuchi", name_short="M", level=1)
         rank = Rank(


### PR DESCRIPTION
## Summary
- auto-populate `Basho.slug` using year and month
- test `Basho` slug creation

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6848737894ec8329928dfe2c6f0e60b4