### PR TITLE
Add Meta and migration for BashoHistory

### DIFF
--- a/app/migrations/0003_bashohistory_meta.py
+++ b/app/migrations/0003_bashohistory_meta.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0002_populate_divisions"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="BashoHistory",
+                    fields=[],
+                    options={
+                        "ordering": ["basho__year", "basho__month", "rikishi_id"],
+                        "verbose_name_plural": "Basho history",
+                        "indexes": [
+                            models.Index(
+                                fields=["rikishi", "basho"],
+                                name="bashohistory_rikishi_basho_idx",
+                            )
+                        ],
+                        "constraints": [
+                            models.UniqueConstraint(
+                                fields=["rikishi", "basho"],
+                                name="unique_rikishi_basho",
+                            )
+                        ],
+                    },
+                )
+            ],
+            database_operations=[],
+        )
+    ]
+

--- a/app/models/history.py
+++ b/app/models/history.py
@@ -21,3 +21,16 @@ class BashoHistory(models.Model):
     )
     height = models.FloatField(blank=True, null=True)
     weight = models.FloatField(blank=True, null=True)
+
+    class Meta:
+        ordering = ["basho__year", "basho__month", "rikishi_id"]
+        verbose_name_plural = "Basho history"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["rikishi", "basho"],
+                name="unique_rikishi_basho",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["rikishi", "basho"]),
+        ]


### PR DESCRIPTION
## Summary
- add Meta options to `BashoHistory`
- add a migration stub updating project state for new Meta options

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6848733498b88329ad8e8a433055eead