### PR TITLE
Refactor constants to use enums

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,28 +1,38 @@
-DIVISIONS = [
-    ("Makuuchi", "M", 1),
-    ("Juryo", "J", 2),
-    ("Makushita", "Ms", 3),
-    ("Sandanme", "Sd", 4),
-    ("Jonidan", "Jd", 5),
-    ("Jonokuchi", "Jk", 6),
-    ("Mae-zumo", "Mz", 7),
-    ("Banzuke-gai", "Bg", 8),
-]
+from enum import Enum
 
-RANK_NAMES = [
-    ("Yokozuna", "Yokozuna"),
-    ("Ozeki", "Ozeki"),
-    ("Sekiwake", "Sekiwake"),
-    ("Komusubi", "Komusubi"),
-    ("Maegashira", "Maegashira"),
-    ("Juryo", "Juryo"),
-    ("Makushita", "Makushita"),
-    ("Sandanme", "Sandanme"),
-    ("Jonidan", "Jonidan"),
-    ("Jonokuchi", "Jonokuchi"),
-    ("Mae-zumo", "Mae-zumo"),
-    ("Banzuke-gai", "Banzuke-gai"),
-]
+from django.db import models
+
+
+class DivisionEnum(Enum):
+    MAKUUCHI = ("Makuuchi", "M", 1)
+    JURYO = ("Juryo", "J", 2)
+    MAKUSHITA = ("Makushita", "Ms", 3)
+    SANDANME = ("Sandanme", "Sd", 4)
+    JONIDAN = ("Jonidan", "Jd", 5)
+    JONOKUCHI = ("Jonokuchi", "Jk", 6)
+    MAEZUMO = ("Mae-zumo", "Mz", 7)
+    BANZUKE_GAI = ("Banzuke-gai", "Bg", 8)
+
+    def __init__(self, label: str, short: str, level: int) -> None:
+        self.label = label
+        self.short = short
+        self.level = level
+
+
+class RankName(models.TextChoices):
+    YOKOZUNA = "Yokozuna", "Yokozuna"
+    OZEKI = "Ozeki", "Ozeki"
+    SEKIWAKE = "Sekiwake", "Sekiwake"
+    KOMUSUBI = "Komusubi", "Komusubi"
+    MAEGASHIRA = "Maegashira", "Maegashira"
+    JURYO = "Juryo", "Juryo"
+    MAKUSHITA = "Makushita", "Makushita"
+    SANDANME = "Sandanme", "Sandanme"
+    JONIDAN = "Jonidan", "Jonidan"
+    JONOKUCHI = "Jonokuchi", "Jonokuchi"
+    MAEZUMO = "Mae-zumo", "Mae-zumo"
+    BANZUKE_GAI = "Banzuke-gai", "Banzuke-gai"
+
 
 RANK_NAMES_SHORT = {
     "Yokozuna": "Y",
@@ -54,7 +64,11 @@ RANKING_LEVELS = {
     "Banzuke-gai": 12,
 }
 
-DIRECTION_NAMES = [("East", "East"), ("West", "West")]
+
+class Direction(models.TextChoices):
+    EAST = "East", "East"
+    WEST = "West", "West"
+
 
 DIRECTION_NAMES_SHORT = {"East": "E", "West": "W"}
 

--- a/app/migrations/0002_populate_divisions.py
+++ b/app/migrations/0002_populate_divisions.py
@@ -1,12 +1,16 @@
 from django.db import migrations
 
-from app.constants import DIVISIONS
+from app.constants import DivisionEnum
 
 
 def populate_divisions(apps, schema_editor):
     Division = apps.get_model("app", "Division")
-    for name, name_short, level in DIVISIONS:
-        Division.objects.create(name=name, name_short=name_short, level=level)
+    for division in DivisionEnum:
+        Division.objects.create(
+            name=division.label,
+            name_short=division.short,
+            level=division.level,
+        )
 
 
 class Migration(migrations.Migration):

--- a/app/models/rank.py
+++ b/app/models/rank.py
@@ -1,10 +1,10 @@
 from django.db import models
 
 from app.constants import (
-    DIRECTION_NAMES,
     DIRECTION_NAMES_SHORT,
-    RANK_NAMES,
     RANK_NAMES_SHORT,
+    Direction,
+    RankName,
 )
 
 from .division import Division
@@ -19,14 +19,16 @@ class Rank(models.Model):
         related_name="ranks",
         editable=False,
     )
-    title = models.CharField(max_length=20, choices=RANK_NAMES, editable=False)
+    title = models.CharField(
+        max_length=20, choices=RankName.choices, editable=False
+    )
     level = models.PositiveSmallIntegerField(editable=False)
     order = models.PositiveSmallIntegerField(
         null=True, blank=True, editable=False
     )
     direction = models.CharField(
         max_length=4,
-        choices=DIRECTION_NAMES,
+        choices=Direction.choices,
         null=True,
         blank=True,
         editable=False,

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
+from app.constants import Direction, RankName
 from app.models.basho import Basho
 from app.models.division import Division
 from app.models.rank import Rank
@@ -26,10 +27,10 @@ class ModelUtilityTests(SimpleTestCase):
         division = Division(name="Makuuchi", name_short="M", level=1)
         rank = Rank(
             division=division,
-            title="Yokozuna",
+            title=RankName.YOKOZUNA,
             level=1,
             order=1,
-            direction="East",
+            direction=Direction.EAST,
         )
         self.assertEqual(str(rank), rank.name())
         self.assertEqual(rank.name(), "Yokozuna 1E")
@@ -38,7 +39,7 @@ class ModelUtilityTests(SimpleTestCase):
 
         rank_no_order = Rank(
             division=division,
-            title="Ozeki",
+            title=RankName.OZEKI,
             level=2,
         )
         self.assertEqual(rank_no_order.name(), "Ozeki")


### PR DESCRIPTION
## Summary
- convert choice tuples in `app/constants.py` to TextChoices and Enum classes
- reference new enums from `Rank` model and populate divisions migration
- use enums in tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68487a00b080832983179ca6f0603f02