### PR TITLE
Add Bout model and importer

### DIFF
--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,1 +1,2 @@
+from .bout import BoutAdmin  # noqa: F401
 from .division import DivisionAdmin  # noqa: F401

--- a/app/admin/bout.py
+++ b/app/admin/bout.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+
+from ..models import Bout
+
+
+@admin.register(Bout)
+class BoutAdmin(admin.ModelAdmin):
+    list_display = [
+        "basho",
+        "division",
+        "day",
+        "match_no",
+        "east",
+        "west",
+        "winner",
+    ]

--- a/app/management/commands/bouts.py
+++ b/app/management/commands/bouts.py
@@ -1,0 +1,60 @@
+import asyncio
+
+from django.core.management.base import BaseCommand
+
+from app.models import Basho, Bout, Division, Rikishi
+from libs.sumoapi import SumoApiClient
+
+
+class Command(BaseCommand):
+    help = "Import bouts for a rikishi"
+
+    def add_arguments(self, parser):
+        parser.add_argument("rikishi_id", nargs="?", type=int)
+        parser.add_argument("--basho", dest="basho_id")
+
+    def handle(self, rikishi_id=None, basho_id=None, **options):
+        asyncio.run(self._handle_async(rikishi_id, basho_id))
+
+    async def _handle_async(self, rikishi_id, basho_id):
+        api = SumoApiClient()
+        rikishi_ids = (
+            [rikishi_id]
+            if rikishi_id
+            else list(await Rikishi.objects.values_list("id", flat=True))
+        )
+        params = {"bashoId": basho_id} if basho_id else {}
+        total = 0
+        for rid in rikishi_ids:
+            data = await api.get_rikishi_matches(rid, **params)
+            records = data.get("records", [])
+            total += len(records)
+            for entry in records:
+                basho_slug = entry.get("bashoId")
+                basho, _ = await Basho.objects.aget_or_create(
+                    slug=basho_slug,
+                    defaults={
+                        "year": int(basho_slug[:4]),
+                        "month": int(basho_slug[-2:]),
+                    },
+                )
+                division = await Division.objects.aget(name=entry["division"])
+                east = await Rikishi.objects.aget(id=entry["eastId"])
+                west = await Rikishi.objects.aget(id=entry["westId"])
+                winner = await Rikishi.objects.aget(id=entry["winnerId"])
+                await Bout.objects.aupdate_or_create(
+                    basho=basho,
+                    day=entry["day"],
+                    match_no=entry["matchNo"],
+                    east=east,
+                    west=west,
+                    defaults={
+                        "division": division,
+                        "east_shikona": entry["eastShikona"],
+                        "west_shikona": entry["westShikona"],
+                        "kimarite": entry["kimarite"],
+                        "winner": winner,
+                    },
+                )
+        await api.aclose()
+        self.stdout.write(self.style.SUCCESS(f"Imported {total} bouts"))

--- a/app/migrations/0004_bout_meta.py
+++ b/app/migrations/0004_bout_meta.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0003_bashohistory_meta"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="Bout",
+                    fields=[],
+                    options={
+                        "verbose_name_plural": "Bouts",
+                        "ordering": [
+                            "basho__year",
+                            "basho__month",
+                            "day",
+                            "match_no",
+                        ],
+                        "indexes": [
+                            models.Index(
+                                fields=["basho", "division", "day"],
+                                name="bout_idx",
+                            )
+                        ],
+                        "constraints": [
+                            models.UniqueConstraint(
+                                fields=[
+                                    "basho",
+                                    "day",
+                                    "match_no",
+                                    "east",
+                                    "west",
+                                ],
+                                name="unique_bout",
+                            )
+                        ],
+                    },
+                )
+            ],
+            database_operations=[],
+        )
+    ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .basho import Basho  # noqa: F401
+from .bout import Bout  # noqa: F401
 from .division import Division  # noqa: F401
 from .history import BashoHistory  # noqa: F401
 from .rank import Rank  # noqa: F401

--- a/app/models/bout.py
+++ b/app/models/bout.py
@@ -1,0 +1,57 @@
+from django.db import models
+
+from .basho import Basho
+from .division import Division
+from .rikishi import Rikishi
+
+
+class Bout(models.Model):
+    """A single bout between two rikishi in a given Basho."""
+
+    basho = models.ForeignKey(
+        Basho,
+        on_delete=models.CASCADE,
+        related_name="bouts",
+    )
+    division = models.ForeignKey(
+        Division,
+        on_delete=models.CASCADE,
+        related_name="bouts",
+    )
+    day = models.PositiveSmallIntegerField()
+    match_no = models.PositiveSmallIntegerField()
+    east = models.ForeignKey(
+        Rikishi,
+        on_delete=models.CASCADE,
+        related_name="bouts_as_east",
+    )
+    west = models.ForeignKey(
+        Rikishi,
+        on_delete=models.CASCADE,
+        related_name="bouts_as_west",
+    )
+    east_shikona = models.CharField(max_length=64)
+    west_shikona = models.CharField(max_length=64)
+    kimarite = models.CharField(max_length=32)
+    winner = models.ForeignKey(
+        Rikishi,
+        on_delete=models.CASCADE,
+        related_name="bouts_won",
+    )
+
+    class Meta:
+        ordering = ["basho__year", "basho__month", "day", "match_no"]
+        verbose_name_plural = "Bouts"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["basho", "day", "match_no", "east", "west"],
+                name="unique_bout",
+            )
+        ]
+        indexes = [models.Index(fields=["basho", "division", "day"])]
+
+    def __str__(self):
+        return (
+            f"{self.basho.slug} Day {self.day} No.{self.match_no}: "
+            f"{self.east_shikona} vs {self.west_shikona}"
+        )

--- a/libs/sumoapi.py
+++ b/libs/sumoapi.py
@@ -62,17 +62,15 @@ class SumoApiClient:
         response.raise_for_status()
         return response.json()
 
-    async def get_rikishi_matches(self, rikishi_id, opponent_id=None):
+    async def get_rikishi_matches(self, rikishi_id, **params):
         """Return a list of matches for a rikishi.
 
-        If ``opponent_id`` is provided only bouts against that opponent are
-        returned.
+        Optional query parameters (e.g., ``bashoId``) are forwarded to the
+        API.
         """
 
         endpoint = f"/rikishi/{rikishi_id}/matches"
-        if opponent_id is not None:
-            endpoint += f"/{opponent_id}"
-        response = await self.client.get(endpoint)
+        response = await self.client.get(endpoint, params=params)
         response.raise_for_status()
         return response.json()
 

--- a/tests/test_models_extra.py
+++ b/tests/test_models_extra.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 
 from app.constants import Direction, RankName
 from app.models.basho import Basho
+from app.models.bout import Bout
 from app.models.division import Division
 from app.models.rank import Rank
 from app.models.rikishi import Heya, Rikishi, Shusshin
@@ -74,3 +75,22 @@ class ModelUtilityTests(SimpleTestCase):
         from app.models import history as mod
 
         self.assertTrue(hasattr(mod, "BashoHistory"))
+
+    def test_bout_str(self):
+        basho = Basho(year=2025, month=5, slug="202505")
+        division = Division(name="Makuuchi", name_short="M", level=1)
+        east = Rikishi(id=1, name="East", name_jp="")
+        west = Rikishi(id=2, name="West", name_jp="")
+        bout = Bout(
+            basho=basho,
+            division=division,
+            day=1,
+            match_no=1,
+            east=east,
+            west=west,
+            east_shikona="East",
+            west_shikona="West",
+            kimarite="yorikiri",
+            winner=east,
+        )
+        self.assertIn("202505", str(bout))

--- a/tests/test_sumoapi.py
+++ b/tests/test_sumoapi.py
@@ -77,7 +77,7 @@ class SumoApiClientTests(SimpleTestCase):
                 self.run_async(api.get_rikishi_matches(1)), {"matches": []}
             )
             self.assertEqual(
-                self.run_async(api.get_rikishi_matches(1, 2)),
+                self.run_async(api.get_rikishi_matches(1, basho_id="202505")),
                 {"matches": []},
             )
             self.assertEqual(


### PR DESCRIPTION
## Summary
- model bouts between rikishi
- expose Bout in admin
- support query params for rikishi match API
- add management command to import bouts
- test Bout string formatting
- test new SumoApiClient argument

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_684883ff028883299e6e2c0228024ea2