### PR TITLE
Add tests for bouts command

### DIFF
--- a/tests/commands/test_bouts_command.py
+++ b/tests/commands/test_bouts_command.py
@@ -1,0 +1,122 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from django.test import SimpleTestCase
+
+from app.management.commands.bouts import Command
+
+
+class BoutsCommandTests(SimpleTestCase):
+    """Tests for the ``bouts`` management command."""
+
+    def run_async(self, coro):
+        """Synchronously run an async coroutine."""
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def get_record(self):
+        return {
+            "bashoId": "202501",
+            "division": "Makuuchi",
+            "day": 1,
+            "matchNo": 1,
+            "eastId": 10,
+            "westId": 11,
+            "eastShikona": "East",
+            "westShikona": "West",
+            "kimarite": "yorikiri",
+            "winnerId": 10,
+        }
+
+    def setup_patches(self):
+        east = SimpleNamespace(id=10)
+        west = SimpleNamespace(id=11)
+        winner = east
+        patches = (
+            patch("app.management.commands.bouts.SumoApiClient"),
+            patch(
+                "app.management.commands.bouts.Basho.objects.aget_or_create",
+                new=AsyncMock(return_value=(SimpleNamespace(), True)),
+            ),
+            patch(
+                "app.management.commands.bouts.Division.objects.aget",
+                new=AsyncMock(return_value=SimpleNamespace()),
+            ),
+            patch(
+                "app.management.commands.bouts.Rikishi.objects.aget",
+                new=AsyncMock(side_effect=[east, west, winner]),
+            ),
+            patch(
+                "app.management.commands.bouts.Bout.objects.aupdate_or_create",
+                new=AsyncMock(),
+            ),
+        )
+        return patches
+
+    def test_parses_and_saves_bout(self):
+        """A single API record should populate model fields."""
+        record = self.get_record()
+        patches = self.setup_patches()
+        with (
+            patches[0] as client_cls,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4] as create_mock,
+        ):
+            api = AsyncMock()
+            client_cls.return_value = api
+            api.get_rikishi_matches.return_value = {"records": [record]}
+            api.aclose.return_value = None
+            cmd = Command()
+            cmd.stdout = SimpleNamespace(write=lambda msg: None)
+            cmd.style = SimpleNamespace(SUCCESS=lambda m: m)
+            self.run_async(cmd._handle_async(1, None))
+            create_mock.assert_awaited_once()
+            kwargs = create_mock.call_args.kwargs
+            self.assertEqual(kwargs["defaults"]["kimarite"], "yorikiri")
+            self.assertEqual(kwargs["day"], 1)
+            self.assertEqual(kwargs["match_no"], 1)
+
+    def test_basho_option_passed_to_api(self):
+        """Passing ``--basho`` should filter API requests."""
+        record = self.get_record()
+        patches = self.setup_patches()
+        with (
+            patches[0] as client_cls,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+        ):
+            api = AsyncMock()
+            client_cls.return_value = api
+            api.get_rikishi_matches.return_value = {"records": [record]}
+            api.aclose.return_value = None
+            cmd = Command()
+            cmd.stdout = SimpleNamespace(write=lambda msg: None)
+            cmd.style = SimpleNamespace(SUCCESS=lambda m: m)
+            self.run_async(cmd._handle_async(1, "202501"))
+            api.get_rikishi_matches.assert_awaited_with(1, bashoId="202501")
+
+    def test_no_records_no_save(self):
+        """No matches should produce no ORM writes."""
+        patches = self.setup_patches()
+        with (
+            patches[0] as client_cls,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4] as create_mock,
+        ):
+            api = AsyncMock()
+            client_cls.return_value = api
+            api.get_rikishi_matches.return_value = {"records": []}
+            api.aclose.return_value = None
+            output = []
+            cmd = Command()
+            cmd.stdout = SimpleNamespace(write=lambda msg: output.append(msg))
+            cmd.style = SimpleNamespace(SUCCESS=lambda m: m)
+            self.run_async(cmd._handle_async(1, None))
+            create_mock.assert_not_awaited()
+            self.assertIn("Imported 0 bouts", output[-1])


### PR DESCRIPTION
## Summary
- add unit tests for the bouts management command
- mock API and ORM methods to check bout parsing and saving
- cover edge cases for `--basho` option and empty API records

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_6848a7076d688329ad6ac94b7af0ac97