### PR TITLE
Fix January basho name to Hatsu

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -76,7 +76,7 @@ class Direction(models.TextChoices):
 DIRECTION_NAMES_SHORT = {"East": "E", "West": "W"}
 
 BASHO_NAMES = {
-    1: "Hastu",
+    1: "Hatsu",
     3: "Haru",
     5: "Natsu",
     7: "Nagoya",

--- a/tests/models/test_extra.py
+++ b/tests/models/test_extra.py
@@ -18,8 +18,8 @@ class ModelUtilityTests(SimpleTestCase):
     def test_basho_methods(self):
         """``Basho.name`` and ``__str__`` should reflect the tournament."""
         basho = Basho(year=2025, month=1)
-        self.assertEqual(basho.name(), "Hastu")  # Month name
-        self.assertEqual(str(basho), "Hastu 2025")  # Includes year
+        self.assertEqual(basho.name(), "Hatsu")  # Month name
+        self.assertEqual(str(basho), "Hatsu 2025")  # Includes year
 
     def test_basho_slug_generation(self):
         """Saving a ``Basho`` should populate the ``slug`` field."""


### PR DESCRIPTION
## Summary
- correct spelling of January basho in constants
- update expectation in tests

## Testing
- `ruff check --fix .`
- `isort .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6848bb04bc448329a9f2f0a15839c5ff