### PR TITLE
Add division detail page with tests

### DIFF
--- a/app/templates/division_detail.html
+++ b/app/templates/division_detail.html
@@ -1,0 +1,6 @@
+{% block content %}
+    <h2>{{ division.name }}</h2>
+    <p>Short name: {{ division.name_short }}</p>
+    <p>Level: {{ division.level }}</p>
+{% endblock %}
+

--- a/tests/views/test_division_detail.py
+++ b/tests/views/test_division_detail.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models.division import Division
+
+
+class DivisionDetailViewTests(TestCase):
+    """Verify behaviour of the division detail view."""
+
+    def test_view_status_code(self):
+        """The detail view should return HTTP 200."""
+        division = Division.objects.get(name="Makuuchi")
+        response = self.client.get(
+            reverse("division-detail", args=[division.name])
+        )
+        self.assertEqual(response.status_code, 200)  # Success
+
+    def test_view_template(self):
+        """The expected template should be used."""
+        division = Division.objects.get(name="Makuuchi")
+        response = self.client.get(
+            reverse("division-detail", args=[division.name])
+        )
+        self.assertTemplateUsed(response, "division_detail.html")


### PR DESCRIPTION
## Summary
- create a simple template for viewing a division
- test that the division detail URL renders correctly

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6848bbb114e48329a36edc4cac900081