### PR TITLE
Refactor command API client usage

### DIFF
--- a/app/management/commands/bouts.py
+++ b/app/management/commands/bouts.py
@@ -17,44 +17,45 @@ class Command(BaseCommand):
         asyncio.run(self._handle_async(rikishi_id, basho_id))
 
     async def _handle_async(self, rikishi_id, basho_id):
-        api = SumoApiClient()
-        rikishi_ids = (
-            [rikishi_id]
-            if rikishi_id
-            else list(await Rikishi.objects.values_list("id", flat=True))
-        )
-        params = {"bashoId": basho_id} if basho_id else {}
-        total = 0
-        for rid in rikishi_ids:
-            data = await api.get_rikishi_matches(rid, **params)
-            records = data.get("records", [])
-            total += len(records)
-            for entry in records:
-                basho_slug = entry.get("bashoId")
-                basho, _ = await Basho.objects.aget_or_create(
-                    slug=basho_slug,
-                    defaults={
-                        "year": int(basho_slug[:4]),
-                        "month": int(basho_slug[-2:]),
-                    },
-                )
-                division = await Division.objects.aget(name=entry["division"])
-                east = await Rikishi.objects.aget(id=entry["eastId"])
-                west = await Rikishi.objects.aget(id=entry["westId"])
-                winner = await Rikishi.objects.aget(id=entry["winnerId"])
-                await Bout.objects.aupdate_or_create(
-                    basho=basho,
-                    day=entry["day"],
-                    match_no=entry["matchNo"],
-                    east=east,
-                    west=west,
-                    defaults={
-                        "division": division,
-                        "east_shikona": entry["eastShikona"],
-                        "west_shikona": entry["westShikona"],
-                        "kimarite": entry["kimarite"],
-                        "winner": winner,
-                    },
-                )
-        await api.aclose()
-        self.stdout.write(self.style.SUCCESS(f"Imported {total} bouts"))
+        async with SumoApiClient() as api:
+            rikishi_ids = (
+                [rikishi_id]
+                if rikishi_id
+                else list(await Rikishi.objects.values_list("id", flat=True))
+            )
+            params = {"bashoId": basho_id} if basho_id else {}
+            total = 0
+            for rid in rikishi_ids:
+                data = await api.get_rikishi_matches(rid, **params)
+                records = data.get("records", [])
+                total += len(records)
+                for entry in records:
+                    basho_slug = entry.get("bashoId")
+                    basho, _ = await Basho.objects.aget_or_create(
+                        slug=basho_slug,
+                        defaults={
+                            "year": int(basho_slug[:4]),
+                            "month": int(basho_slug[-2:]),
+                        },
+                    )
+                    division = await Division.objects.aget(
+                        name=entry["division"]
+                    )
+                    east = await Rikishi.objects.aget(id=entry["eastId"])
+                    west = await Rikishi.objects.aget(id=entry["westId"])
+                    winner = await Rikishi.objects.aget(id=entry["winnerId"])
+                    await Bout.objects.aupdate_or_create(
+                        basho=basho,
+                        day=entry["day"],
+                        match_no=entry["matchNo"],
+                        east=east,
+                        west=west,
+                        defaults={
+                            "division": division,
+                            "east_shikona": entry["eastShikona"],
+                            "west_shikona": entry["westShikona"],
+                            "kimarite": entry["kimarite"],
+                            "winner": winner,
+                        },
+                    )
+            self.stdout.write(self.style.SUCCESS(f"Imported {total} bouts"))

--- a/app/management/commands/populate.py
+++ b/app/management/commands/populate.py
@@ -44,13 +44,11 @@ class Command(BaseCommand):
         asyncio.run(self._handle_async())
 
     async def _handle_async(self):
-        api = SumoApiClient()
-
-        await self._populate_divisions()
-        self.log("Fetching rikishi from API...")
-        rikishi_data = await api.get_all_rikishi()
-        await api.aclose()
-        self.log(f"Fetched {len(rikishi_data)} rikishi.")
+        async with SumoApiClient() as api:
+            await self._populate_divisions()
+            self.log("Fetching rikishi from API...")
+            rikishi_data = await api.get_all_rikishi()
+            self.log(f"Fetched {len(rikishi_data)} rikishi.")
 
         # Prefetch caches
         existing_rikishi = await sync_to_async(

--- a/tests/commands/test_bouts_command.py
+++ b/tests/commands/test_bouts_command.py
@@ -65,9 +65,9 @@ class BoutsCommandTests(SimpleTestCase):
             patches[4] as create_mock,
         ):
             api = AsyncMock()
-            client_cls.return_value = api
+            client_cls.return_value.__aenter__.return_value = api
+            client_cls.return_value.__aexit__.return_value = None
             api.get_rikishi_matches.return_value = {"records": [record]}
-            api.aclose.return_value = None
             cmd = Command()
             cmd.stdout = SimpleNamespace(write=lambda msg: None)
             cmd.style = SimpleNamespace(SUCCESS=lambda m: m)
@@ -90,9 +90,9 @@ class BoutsCommandTests(SimpleTestCase):
             patches[4],
         ):
             api = AsyncMock()
-            client_cls.return_value = api
+            client_cls.return_value.__aenter__.return_value = api
+            client_cls.return_value.__aexit__.return_value = None
             api.get_rikishi_matches.return_value = {"records": [record]}
-            api.aclose.return_value = None
             cmd = Command()
             cmd.stdout = SimpleNamespace(write=lambda msg: None)
             cmd.style = SimpleNamespace(SUCCESS=lambda m: m)
@@ -110,9 +110,9 @@ class BoutsCommandTests(SimpleTestCase):
             patches[4] as create_mock,
         ):
             api = AsyncMock()
-            client_cls.return_value = api
+            client_cls.return_value.__aenter__.return_value = api
+            client_cls.return_value.__aexit__.return_value = None
             api.get_rikishi_matches.return_value = {"records": []}
-            api.aclose.return_value = None
             output = []
             cmd = Command()
             cmd.stdout = SimpleNamespace(write=lambda msg: output.append(msg))

--- a/tests/commands/test_populate_command.py
+++ b/tests/commands/test_populate_command.py
@@ -81,10 +81,10 @@ class PopulateCommandTests(SimpleTestCase):
 
             search_fuzzy.return_value = [SimpleNamespace(name="Japan")]
 
-            mock_client = AsyncMock()
-            client_cls.return_value = mock_client
-            mock_client.get_all_rikishi.return_value = rikishi_data
-            mock_client.aclose.return_value = None
+            mock_api = AsyncMock()
+            client_cls.return_value.__aenter__.return_value = mock_api
+            client_cls.return_value.__aexit__.return_value = None
+            mock_api.get_all_rikishi.return_value = rikishi_data
 
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
@@ -94,7 +94,7 @@ class PopulateCommandTests(SimpleTestCase):
                 asyncio.set_event_loop(asyncio.new_event_loop())
                 loop.close()
 
-            mock_client.get_all_rikishi.assert_awaited_once()
+            mock_api.get_all_rikishi.assert_awaited_once()
             ro.abulk_create.assert_awaited_once()
             ro.abulk_update.assert_not_called()
 
@@ -152,10 +152,10 @@ class PopulateCommandTests(SimpleTestCase):
                 return_value=(Shusshin(name="S"), True)
             )
 
-            mock_client = AsyncMock()
-            client_cls.return_value = mock_client
-            mock_client.get_all_rikishi.return_value = rikishi_data
-            mock_client.aclose.return_value = None
+            mock_api = AsyncMock()
+            client_cls.return_value.__aenter__.return_value = mock_api
+            client_cls.return_value.__aexit__.return_value = None
+            mock_api.get_all_rikishi.return_value = rikishi_data
 
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
@@ -237,10 +237,10 @@ class PopulateCommandTests(SimpleTestCase):
                 [SimpleNamespace(name="Mongolia")],
             ]
 
-            mock_client = AsyncMock()
-            client_cls.return_value = mock_client
-            mock_client.get_all_rikishi.return_value = rikishi_data
-            mock_client.aclose.return_value = None
+            mock_api = AsyncMock()
+            client_cls.return_value.__aenter__.return_value = mock_api
+            client_cls.return_value.__aexit__.return_value = None
+            mock_api.get_all_rikishi.return_value = rikishi_data
 
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/tests/commands/test_ranking_command.py
+++ b/tests/commands/test_ranking_command.py
@@ -96,7 +96,8 @@ class RankingCommandTests(SimpleTestCase):
             ) as mock_client_cls,
         ):
             mock_api = AsyncMock()
-            mock_client_cls.return_value = mock_api
+            mock_client_cls.return_value.__aenter__.return_value = mock_api
+            mock_client_cls.return_value.__aexit__.return_value = None
             mock_api.get_ranking_history.return_value = {
                 1: [{"bashoId": "202501", "rank": "Y1E"}]
             }
@@ -108,7 +109,6 @@ class RankingCommandTests(SimpleTestCase):
                 }
             ]
             mock_api.get_basho_by_id.return_value = None
-            mock_api.aclose.return_value = None
 
             cmd = Command()
             cmd.log = lambda *a, **k: None
@@ -156,7 +156,8 @@ class RankingCommandTests(SimpleTestCase):
             ) as mock_client_cls,
         ):
             mock_api = AsyncMock()
-            mock_client_cls.return_value = mock_api
+            mock_client_cls.return_value.__aenter__.return_value = mock_api
+            mock_client_cls.return_value.__aexit__.return_value = None
             mock_api.get_ranking_history.return_value = {
                 1: [{"bashoId": "202504", "rank": "Y1E"}]
             }
@@ -164,7 +165,6 @@ class RankingCommandTests(SimpleTestCase):
                 {"bashoId": "202503", "shikonaEn": "Later", "shikonaJp": "後"}
             ]
             mock_api.get_basho_by_id.return_value = None
-            mock_api.aclose.return_value = None
 
             cmd = Command()
             cmd.log = lambda *a, **k: None
@@ -212,7 +212,8 @@ class RankingCommandTests(SimpleTestCase):
             ) as mock_client_cls,
         ):
             mock_api = AsyncMock()
-            mock_client_cls.return_value = mock_api
+            mock_client_cls.return_value.__aenter__.return_value = mock_api
+            mock_client_cls.return_value.__aexit__.return_value = None
             mock_api.get_ranking_history.return_value = {
                 1: [{"bashoId": "202501", "rank": "Y1E"}]
             }
@@ -220,7 +221,6 @@ class RankingCommandTests(SimpleTestCase):
                 {"bashoId": "202503", "shikonaEn": "Future", "shikonaJp": "未"}
             ]
             mock_api.get_basho_by_id.return_value = None
-            mock_api.aclose.return_value = None
 
             cmd = Command()
             cmd.log = lambda *a, **k: None
@@ -323,7 +323,8 @@ class RankingCommandTests(SimpleTestCase):
             ),
         ):
             api = AsyncMock()
-            client_cls.return_value = api
+            client_cls.return_value.__aenter__.return_value = api
+            client_cls.return_value.__aexit__.return_value = None
             api.get_ranking_history.return_value = {1: entries}
             api.get_shikonas.return_value = []
             api.get_basho_by_id.side_effect = [
@@ -334,7 +335,6 @@ class RankingCommandTests(SimpleTestCase):
                 },
                 None,
             ]
-            api.aclose.return_value = None
             cmd = Command()
             cmd.log = lambda *a, **k: None
             cmd.create_basho_from_api = AsyncMock(


### PR DESCRIPTION
## Summary
- use `SumoApiClient` as an async context manager
- drop explicit `aclose` calls
- patch command tests for context manager support

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_6848bbddc71883298419c3b86f30f952