### PR TITLE
Support custom Sumo API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This project requires **Python 3.12** or later.
    ```bash
    cp .env.example .env
    ```
+   Set the `SUMO_API_URL` environment variable if you need to point to a
+   custom Sumo API instance.
 4. Apply the initial database migrations:
    ```bash
    python manage.py migrate

--- a/libs/sumoapi.py
+++ b/libs/sumoapi.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import httpx
 
@@ -10,6 +11,7 @@ class SumoApiError(Exception):
 
 
 BASE_URL = "https://sumo-api.com/api"
+ENV_BASE_URL = "SUMO_API_URL"
 
 
 class SumoApiClient:
@@ -25,7 +27,8 @@ class SumoApiClient:
             and ``timeout`` are preconfigured but can be overridden.
         """
 
-        default_kwargs = {"base_url": BASE_URL, "timeout": 30.0}
+        base_url = os.getenv(ENV_BASE_URL, BASE_URL)
+        default_kwargs = {"base_url": base_url, "timeout": 30.0}
         default_kwargs.update(client_kwargs)
         self.client = httpx.AsyncClient(**default_kwargs)
 

--- a/tests/libs/test_sumoapi.py
+++ b/tests/libs/test_sumoapi.py
@@ -183,3 +183,15 @@ class SumoApiClientTests(SimpleTestCase):
             with self.assertRaises(SumoApiError):
                 self.run_async(api.get_all_rikishi())
             self.run_async(api.__aexit__(None, None, None))
+
+    def test_env_base_url_override(self):
+        """Environment variable should override the default base URL."""
+
+        with (
+            patch.dict("os.environ", {"SUMO_API_URL": "https://example.test"}),
+            patch("libs.sumoapi.httpx.AsyncClient") as mock_client,
+        ):
+            SumoApiClient()
+            mock_client.assert_called_with(
+                base_url="https://example.test", timeout=30.0
+            )


### PR DESCRIPTION
## Summary
- allow overriding `SumoApiClient` base URL via `SUMO_API_URL`
- document the new environment variable
- test base URL override via environment variable

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6848c6d6c7c88329a3fd58de3f2467b4