### PR TITLE
Add meta migrations for remaining models

### DIFF
--- a/app/migrations/0006_add_models_meta.py
+++ b/app/migrations/0006_add_models_meta.py
@@ -1,0 +1,60 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0005_bout_meta"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="Basho",
+                    fields=[],
+                    options={
+                        "verbose_name_plural": "Basho",
+                        "indexes": [
+                            models.Index(fields=["year", "month"], name="basho_year_month_idx"),
+                        ],
+                        "constraints": [
+                            models.UniqueConstraint(fields=["year", "month"], name="unique_basho"),
+                        ],
+                    },
+                ),
+                migrations.CreateModel(
+                    name="Heya",
+                    fields=[],
+                    options={
+                        "ordering": ["name"],
+                        "verbose_name_plural": "Heya",
+                    },
+                ),
+                migrations.CreateModel(
+                    name="Rank",
+                    fields=[],
+                    options={
+                        "ordering": ["division__level", "level", "order", "direction"],
+                        "unique_together": {("title", "order", "direction", "division")},
+                    },
+                ),
+                migrations.CreateModel(
+                    name="Rikishi",
+                    fields=[],
+                    options={
+                        "ordering": ["name"],
+                        "verbose_name_plural": "Rikishi",
+                    },
+                ),
+                migrations.CreateModel(
+                    name="Shusshin",
+                    fields=[],
+                    options={
+                        "ordering": ["international", "name"],
+                        "verbose_name_plural": "Shusshin",
+                    },
+                ),
+            ],
+            database_operations=[],
+        )
+    ]


### PR DESCRIPTION
## Summary
- add migration for Basho, Rank, Rikishi, Heya and Shusshin models
- ensure unique/index constraints are defined
- migrations apply cleanly on a blank database

## Testing
- `coverage run manage.py test`
- `python manage.py migrate`

------
https://chatgpt.com/codex/tasks/task_e_68494051262c83299af91ee69fd2bbeb