### PR TITLE
Add measurement import to ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project requires **Python 3.12** or later.
 5. (Optional) populate the database using these commands:
    ```bash
    python manage.py populate  # fetches rikishi data and fills the DB
-   python manage.py ranking   # imports ranking & shikona history
+   python manage.py ranking   # imports ranking, shikona & measurements history
    ```
 
 ## Running the development server


### PR DESCRIPTION
## Summary
- import height and weight history from sumo-api
- fall back to prior measurement data like shikona
- document new behaviour in README
- test measurement import and fallback logic

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_684947c1a4b8832999f564f19e360568