### PR TITLE
Add root index page

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import DivisionDetailView, DivisionListView
+from .views import DivisionDetailView, DivisionListView, IndexView
 
 urlpatterns = [
+    path("", IndexView.as_view(), name="index"),
     path("division/", DivisionListView.as_view(), name="division-list"),
     path(
         "division/<slug:slug>",

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,10 @@
-from django.views.generic import DetailView, ListView
+from django.views.generic import DetailView, ListView, TemplateView
 
 from .models import Division
+
+
+class IndexView(TemplateView):
+    template_name = "index.html"
 
 
 class DivisionListView(ListView):

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,9 @@
+{% block content %}
+    <h2>Welcome to Sumoracle</h2>
+    <p>Browse divisions and rikishi information.</p>
+    <nav>
+        <ul>
+            <li><a href="{% url 'division-list' %}">Divisions</a></li>
+        </ul>
+    </nav>
+{% endblock %}

--- a/tests/views/test_index.py
+++ b/tests/views/test_index.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class IndexViewTests(TestCase):
+    """Verify behaviour of the index view."""
+
+    def test_view_status_code(self):
+        """The index view should return HTTP 200."""
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_template(self):
+        """The expected template should be used."""
+        response = self.client.get(reverse("index"))
+        self.assertTemplateUsed(response, "index.html")
+
+    def test_view_links_to_division_list(self):
+        """The page should provide a link to the divisions list."""
+        response = self.client.get(reverse("index"))
+        self.assertContains(response, reverse("division-list"))


### PR DESCRIPTION
## Summary
- handle the root URL with a new IndexView
- link the IndexView from `app.urls`
- create `index.html` template
- add navigation link to divisions list
- test the new view and link

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68494b9a00708329bd92c871d744c097