### PR TITLE
Add Docker entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
 ENV PYTHONUNBUFFERED=1 \
     DJANGO_SETTINGS_MODULE=config.settings
 
 EXPOSE 8000
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["gunicorn", "config.asgi:application", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# Determine database host and port
+if [ -n "$DATABASE_URL" ]; then
+    db_host=$(echo "$DATABASE_URL" | sed -e 's|.*@||' -e 's|:.*||')
+    db_port=$(echo "$DATABASE_URL" | sed -e 's|.*:||' -e 's|/.*||')
+else
+    db_host=${DATABASE_HOST:-db}
+    db_port=${DATABASE_PORT:-5432}
+fi
+
+printf 'Waiting for database at %s:%s...\n' "$db_host" "$db_port"
+while ! nc -z "$db_host" "$db_port"; do
+    sleep 1
+    printf '.'
+done
+printf '\nDatabase is available. Applying migrations...\n'
+
+python manage.py migrate --noinput
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a `docker-entrypoint.sh` that waits for the DB and runs migrations
- update Dockerfile to install and use the entrypoint script

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_684966f59c488329b41116857eb6b11c