### PR TITLE
Add health checks to Docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 EXPOSE 8000
 
+HEALTHCHECK CMD curl -f http://localhost:8000/ || exit 1
+
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["gunicorn", "config.asgi:application", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - .env
     depends_on:
       - db
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://web:8000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
   db:
     image: postgres:latest
     environment:


### PR DESCRIPTION
## Summary
- add health check for the `web` service in docker-compose
- add Dockerfile `HEALTHCHECK` instruction

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68496888677c832988e983475825d252