### PR TITLE
Add configurable logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 SECRET_KEY=replace-this-secret-key
 DEBUG=True
+# Logging level for Django
+LOG_LEVEL=INFO
 # Space-separated list
 ALLOWED_HOSTS=localhost 127.0.0.1
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ This project requires **Python 3.12** or later.
    ```
 3. Create a `.env` file from the example and adjust the values:
    ```bash
-   cp .env.example .env
-   ```
-   Do not commit the `.env` file to version control.
-   Set the `SUMO_API_URL` environment variable if you need to point to a
-   custom Sumo API instance.
+  cp .env.example .env
+  ```
+  Do not commit the `.env` file to version control.
+  Set the `SUMO_API_URL` environment variable if you need to point to a
+  custom Sumo API instance. Use `LOG_LEVEL` to change the Django logging
+  verbosity (default: `INFO`).
 4. Apply the initial database migrations:
    ```bash
    python manage.py migrate

--- a/config/settings.py
+++ b/config/settings.py
@@ -29,6 +29,9 @@ SECRET_KEY = os.environ.get(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "True") == "True"
 
+# Default log level for the ``LOGGING`` config.
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+
 ALLOWED_HOSTS = (
     os.environ.get("ALLOWED_HOSTS", "").split()
     if os.environ.get("ALLOWED_HOSTS")
@@ -139,3 +142,35 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Basic logging configuration directing output to stdout/stderr.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "format": "[{levelname}] {name}: {message}",
+            "style": "{",
+        }
+    },
+    "handlers": {
+        "stdout": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "default",
+        },
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+            "formatter": "default",
+        },
+    },
+    "root": {"handlers": ["stdout"], "level": LOG_LEVEL},
+    "loggers": {
+        "django.request": {
+            "handlers": ["stderr"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        }
+    },
+}


### PR DESCRIPTION
## Summary
- add `LOG_LEVEL` in config and `.env.example`
- log to stdout/stderr using LOG_LEVEL
- document the new variable in README

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_684969f886088329822ceb00ef6b03f2