### PR TITLE
Add Rikishi list view

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -1,9 +1,15 @@
 from django.urls import path
 
-from .views import DivisionDetailView, DivisionListView, IndexView
+from .views import (
+    DivisionDetailView,
+    DivisionListView,
+    IndexView,
+    RikishiListView,
+)
 
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
+    path("rikishi/", RikishiListView.as_view(), name="rikishi-list"),
     path("division/", DivisionListView.as_view(), name="division-list"),
     path(
         "division/<slug:slug>",

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,6 @@
 from django.views.generic import DetailView, ListView, TemplateView
 
-from .models import Division
+from .models import Division, Rikishi
 
 
 class IndexView(TemplateView):
@@ -18,3 +18,23 @@ class DivisionDetailView(DetailView):
     slug_field = "name"
     slug_url_kwarg = "slug"
     context_object_name = "division"
+
+
+class RikishiListView(ListView):
+    model = Rikishi
+    template_name = "rikishi_list.html"
+    paginate_by = 50
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.GET.get("active") is not None:
+            queryset = queryset.filter(intai__isnull=True)
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        active = self.request.GET.get("active") is not None
+        context["active_only"] = active
+        base = self.request.path
+        context["toggle_url"] = base if active else f"{base}?active=1"
+        return context

--- a/templates/rikishi_list.html
+++ b/templates/rikishi_list.html
@@ -1,0 +1,59 @@
+{% block content %}
+    <h2>Rikishi</h2>
+    <p>
+        <a href="{{ toggle_url }}">
+            {% if active_only %}Show all{% else %}Show active{% endif %}
+        </a>
+    </p>
+    <table id="rikishi-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Japanese</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for rikishi in object_list %}
+                <tr>
+                    <td>{{ rikishi.name }}</td>
+                    <td>{{ rikishi.name_jp }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <script>
+        let page = 2;
+        const active = {{ active_only|yesno:"true,false" }};
+        let loading = false;
+        async function load() {
+            if (loading) {
+                return;
+            }
+            if (
+                window.innerHeight + window.scrollY >=
+                document.body.offsetHeight - 20
+            ) {
+                loading = true;
+                const url =
+                    "{% url 'rikishi-list' %}?page=" +
+                    page +
+                    (active ? "&active=1" : "");
+                const resp = await fetch(url);
+                const html = await resp.text();
+                const doc = new DOMParser().parseFromString(html, "text/html");
+                const rows =
+                    doc.querySelectorAll("#rikishi-table tbody tr");
+                if (rows.length === 0) {
+                    window.removeEventListener("scroll", load);
+                } else {
+                    document
+                        .querySelector("#rikishi-table tbody")
+                        .append(...rows);
+                    page += 1;
+                    loading = false;
+                }
+            }
+        }
+        window.addEventListener("scroll", load);
+    </script>
+{% endblock %}

--- a/tests/views/test_rikishi_list.py
+++ b/tests/views/test_rikishi_list.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models.rikishi import Rikishi
+
+
+class RikishiListViewTests(TestCase):
+    """Verify behaviour of the rikishi list view."""
+
+    def setUp(self):
+        Rikishi.objects.create(id=1, name="Hakuho", name_jp="白鵬")
+        Rikishi.objects.create(id=2, name="Kakuryu", name_jp="鶴竜")
+        Rikishi.objects.create(
+            id=3,
+            name="Chiyotaikai",
+            name_jp="千代大海",
+            intai=date(2020, 1, 1),
+        )
+
+    def test_view_status_code(self):
+        """The list view should return HTTP 200."""
+        response = self.client.get(reverse("rikishi-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_template(self):
+        """The expected template should be used."""
+        response = self.client.get(reverse("rikishi-list"))
+        self.assertTemplateUsed(response, "rikishi_list.html")
+
+    def test_view_lists_all_rikishi(self):
+        """Paginator count should match the database."""
+        response = self.client.get(reverse("rikishi-list"))
+        self.assertEqual(
+            response.context["paginator"].count,
+            Rikishi.objects.count(),
+        )
+
+    def test_active_filter(self):
+        """Filtering by active should exclude retired rikishi."""
+        url = reverse("rikishi-list") + "?active=1"
+        response = self.client.get(url)
+        names = [r.name for r in response.context["object_list"]]
+        self.assertNotIn("Chiyotaikai", names)
+        self.assertEqual(
+            response.context["paginator"].count,
+            Rikishi.objects.filter(intai__isnull=True).count(),
+        )
+        self.assertTrue(response.context["active_only"])


### PR DESCRIPTION
## Summary
- list Rikishi with `RikishiListView`
- expose new URL `/rikishi/`
- render a basic table of Rikishi
- test Rikishi list view
- add filter toggle for active rikishi only
- support infinite scroll via JavaScript

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68541bf046b88329a06220b0a2a83f18