### PR TITLE
Implement HTMX infinite scroll

### DIFF
--- a/app/views/rikishi.py
+++ b/app/views/rikishi.py
@@ -7,6 +7,12 @@ class RikishiListView(ListView):
     model = Rikishi
     template_name = "rikishi_list.html"
     paginate_by = 50
+    partial_template_name = "partials/rikishi_rows.html"
+
+    def get_template_names(self):
+        if self.request.headers.get("HX-Request"):
+            return [self.partial_template_name]
+        return [self.template_name]
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/templates/partials/rikishi_rows.html
+++ b/templates/partials/rikishi_rows.html
@@ -1,0 +1,16 @@
+{% for rikishi in object_list %}
+<tr>
+    <td>{{ rikishi.rank }}</td>
+    <td>
+        <a href="{% url 'rikishi-detail' rikishi.id %}">{{ rikishi.name }}</a>
+    </td>
+    <td>{{ rikishi.name_jp }}</td>
+</tr>
+{% endfor %}
+{% if page_obj.has_next %}
+<tr hx-get="{% url 'rikishi-list' %}?page={{ page_obj.next_page_number }}{% if active_only %}&active=1{% endif %}"
+    hx-trigger="revealed"
+    hx-swap="outerHTML">
+    <td colspan="2">Loading...</td>
+</tr>
+{% endif %}

--- a/templates/rikishi_list.html
+++ b/templates/rikishi_list.html
@@ -14,52 +14,8 @@
             </tr>
         </thead>
         <tbody>
-            {% for rikishi in object_list %}
-                <tr>
-                    <td>{{ rikishi.rank }}</td>
-                    <td>
-                        <a href="{% url 'rikishi-detail' rikishi.id %}">
-                            {{ rikishi.name }}
-                        </a>
-                    </td>
-                    <td>{{ rikishi.name_jp }}</td>
-                </tr>
-            {% endfor %}
+            {% include "partials/rikishi_rows.html" %}
         </tbody>
     </table>
-    <script>
-        let page = 2;
-        const active = {{ active_only|yesno:"true,false" }};
-        let loading = false;
-        async function load() {
-            if (loading) {
-                return;
-            }
-            if (
-                window.innerHeight + window.scrollY >=
-                document.body.offsetHeight - 20
-            ) {
-                loading = true;
-                const url =
-                    "{% url 'rikishi-list' %}?page=" +
-                    page +
-                    (active ? "&active=1" : "");
-                const resp = await fetch(url);
-                const html = await resp.text();
-                const doc = new DOMParser().parseFromString(html, "text/html");
-                const rows =
-                    doc.querySelectorAll("#rikishi-table tbody tr");
-                if (rows.length === 0) {
-                    window.removeEventListener("scroll", load);
-                } else {
-                    document
-                        .querySelector("#rikishi-table tbody")
-                        .append(...rows);
-                    page += 1;
-                    loading = false;
-                }
-            }
-        }
-        window.addEventListener("scroll", load);
-    </script>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- swap raw JS for HTMX infinite scrolling
- render HTMX partial when request comes from HTMX

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68543e2f5b788329bd1dfaf3df65471c