### PR TITLE
Add Halfmoon base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}Sumoracle{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'css/halfmoon.min.css' %}">
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    {% block extra_head %}{% endblock %}
+</head>
+<body class="with-custom-webkit-scrollbars">
+    <nav class="navbar">
+        <!-- Navigation placeholder -->
+    </nav>
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `templates/base.html`
- include Halfmoon CSS and Bootstrap JS assets
- define template blocks and navbar placeholder

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68545f9d3ba483299580885288e3d4f2