### PR TITLE
Improve division templates

### DIFF
--- a/templates/division_detail.html
+++ b/templates/division_detail.html
@@ -1,6 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}{{ division.name }}{% endblock %}
+
 {% block content %}
-    <h2>{{ division.name }}</h2>
-    <p>Short name: {{ division.name_short }}</p>
-    <p>Level: {{ division.level }}</p>
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">{{ division.name }}</h2>
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item">Short name: {{ division.name_short }}</li>
+            <li class="list-group-item">Level: {{ division.level }}</li>
+        </ul>
+    </div>
+</div>
 {% endblock %}
 

--- a/templates/division_list.html
+++ b/templates/division_list.html
@@ -1,8 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Divisions{% endblock %}
+
 {% block content %}
-    <h2>Divisions</h2>
-    <ul>
-        {% for division in object_list %}
-            <li><a href="{{ division.get_absolute_url }}">{{ division.name }}</a></li>
-        {% endfor %}
-    </ul>
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">Divisions</h2>
+        <ul class="list-group list-group-flush">
+            {% for division in object_list %}
+            <li class="list-group-item">
+                <a href="{{ division.get_absolute_url }}">{{ division.name }}</a>
+            </li>
+            {% empty %}
+            <li class="list-group-item">No divisions available.</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- modernize division list/detail templates
- add Halfmoon cards and list groups
- extend from base template

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_685463d9b584832985bed255f97b4593