### PR TITLE
Improve rikishi templates

### DIFF
--- a/templates/rikishi_detail.html
+++ b/templates/rikishi_detail.html
@@ -1,13 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}{{ rikishi.name }}{% endblock %}
+
 {% block content %}
-    <h2>{{ rikishi.name }}</h2>
-    <p>Rank: {{ rikishi.rank }}</p>
-    <p>Heya: {{ rikishi.heya }}</p>
-    <p>Shusshin: {{ rikishi.shusshin }}</p>
-    <p>Height: {{ rikishi.height }} / Weight: {{ rikishi.weight }}</p>
-    <h3>Basho History</h3>
-    <ul>
-        {% for record in rikishi.ranking_history.all %}
-            <li>{{ record.basho.slug }} - {{ record.rank.long_name }}</li>
-        {% endfor %}
-    </ul>
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">{{ rikishi.name }}</h2>
+        <p>
+            Rank:
+            <span class="badge badge-primary">
+                {{ rikishi.rank.long_name }}
+            </span>
+        </p>
+        <p>
+            Heya:
+            <span class="badge badge-secondary">{{ rikishi.heya }}</span>
+        </p>
+        <p>
+            Shusshin:
+            <span class="badge badge-secondary">{{ rikishi.shusshin }}</span>
+        </p>
+        <p>Height: {{ rikishi.height }} / Weight: {{ rikishi.weight }}</p>
+        <h3 class="mt-4">Basho History</h3>
+        <ul class="list-group list-group-flush">
+            {% for record in rikishi.ranking_history.all %}
+            <li class="list-group-item">
+                <span class="badge badge-primary">{{ record.basho.slug }}</span>
+                {{ record.rank.long_name }}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/rikishi_list.html
+++ b/templates/rikishi_list.html
@@ -1,20 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Rikishi{% endblock %}
+
 {% block content %}
-    <h2>Rikishi</h2>
-    <p>
-        <a href="{{ toggle_url }}">
-            {% if active_only %}Show all{% else %}Show active{% endif %}
-        </a>
-    </p>
-    <table id="rikishi-table">
-        <thead>
-            <tr>
-                <th>Rank</th>
-                <th>Name</th>
-                <th>Japanese</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% include "partials/rikishi_rows.html" %}
-        </tbody>
-    </table>
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">Rikishi</h2>
+        <p>
+            <a href="{{ toggle_url }}">
+                {% if active_only %}Show all{% else %}Show active{% endif %}
+            </a>
+        </p>
+        <table id="rikishi-table" class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Rank</th>
+                    <th>Name</th>
+                    <th>Japanese</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% include "partials/rikishi_rows.html" %}
+            </tbody>
+        </table>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend `base.html` for rikishi pages
- use Halfmoon components for list and detail views

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6854656201bc8329b774509ed159f0ec