### PR TITLE
Add basho views and templates

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 
 from .views import (
+    BashoDetailView,
+    BashoListView,
     DivisionDetailView,
     DivisionListView,
     IndexView,
@@ -21,5 +23,11 @@ urlpatterns = [
         "division/<slug:slug>",
         DivisionDetailView.as_view(),
         name="division-detail",
+    ),
+    path("basho/", BashoListView.as_view(), name="basho-list"),
+    path(
+        "basho/<slug:slug>",
+        BashoDetailView.as_view(),
+        name="basho-detail",
     ),
 ]

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,3 +1,4 @@
+from .basho import BashoDetailView, BashoListView  # noqa: F401
 from .division import DivisionDetailView, DivisionListView  # noqa: F401
 from .index import IndexView  # noqa: F401
 from .rikishi import RikishiDetailView, RikishiListView  # noqa: F401
@@ -6,6 +7,8 @@ __all__ = [
     "IndexView",
     "DivisionListView",
     "DivisionDetailView",
+    "BashoListView",
+    "BashoDetailView",
     "RikishiListView",
     "RikishiDetailView",
 ]

--- a/app/views/basho.py
+++ b/app/views/basho.py
@@ -1,0 +1,21 @@
+from django.views.generic import DetailView, ListView
+
+from ..models import Basho
+
+
+class BashoListView(ListView):
+    """List all basho ordered by most recent."""
+
+    model = Basho
+    template_name = "basho_list.html"
+    ordering = ["-year", "-month"]
+
+
+class BashoDetailView(DetailView):
+    """Display details for a single basho."""
+
+    model = Basho
+    template_name = "basho_detail.html"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
+    context_object_name = "basho"

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,9 @@
                         <a class="nav-link" href="{% url 'division-list' %}">Divisions</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{% url 'basho-list' %}">Basho</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{% url 'rikishi-list' %}">Rikishi</a>
                     </li>
                 </ul>

--- a/templates/basho_detail.html
+++ b/templates/basho_detail.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block title %}{{ basho }}{% endblock %}
+
+{% block content %}
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">{{ basho }}</h2>
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item">Slug: {{ basho.slug }}</li>
+            <li class="list-group-item">Year: {{ basho.year }}</li>
+            <li class="list-group-item">Month: {{ basho.month }}</li>
+            {% if basho.start_date %}
+            <li class="list-group-item">Start: {{ basho.start_date }}</li>
+            {% endif %}
+            {% if basho.end_date %}
+            <li class="list-group-item">End: {{ basho.end_date }}</li>
+            {% endif %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/templates/basho_list.html
+++ b/templates/basho_list.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Basho{% endblock %}
+
+{% block content %}
+<div class="card my-3">
+    <div class="card-body">
+        <h2 class="card-title">Basho</h2>
+        <ul class="list-group list-group-flush">
+            {% for basho in object_list %}
+            <li class="list-group-item">
+                <a href="{% url 'basho-detail' basho.slug %}">{{ basho }}</a>
+            </li>
+            {% empty %}
+            <li class="list-group-item">No basho available.</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/tests/views/test_basho_detail.py
+++ b/tests/views/test_basho_detail.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models.basho import Basho
+
+
+class BashoDetailViewTests(TestCase):
+    """Verify behaviour of the basho detail view."""
+
+    def setUp(self):
+        self.basho = Basho.objects.create(year=2025, month=1)
+
+    def test_view_status_code(self):
+        response = self.client.get(
+            reverse("basho-detail", args=[self.basho.slug])
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_template_and_content(self):
+        response = self.client.get(
+            reverse("basho-detail", args=[self.basho.slug])
+        )
+        self.assertTemplateUsed(response, "basho_detail.html")
+        self.assertContains(response, self.basho.slug)
+        self.assertContains(response, str(self.basho.year))
+        self.assertContains(response, str(self.basho.month))

--- a/tests/views/test_basho_list.py
+++ b/tests/views/test_basho_list.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models.basho import Basho
+
+
+class BashoListViewTests(TestCase):
+    """Verify behaviour of the basho list view."""
+
+    def setUp(self):
+        Basho.objects.create(year=2025, month=1)
+        Basho.objects.create(year=2025, month=3)
+
+    def test_view_status_code(self):
+        response = self.client.get(reverse("basho-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_template(self):
+        response = self.client.get(reverse("basho-list"))
+        self.assertTemplateUsed(response, "basho_list.html")
+
+    def test_view_lists_all_basho(self):
+        response = self.client.get(reverse("basho-list"))
+        self.assertEqual(
+            response.context["object_list"].count(),
+            Basho.objects.count(),
+        )
+
+    def test_names_link_to_detail(self):
+        response = self.client.get(reverse("basho-list"))
+        for basho in Basho.objects.all():
+            detail_url = reverse("basho-detail", args=[basho.slug])
+            self.assertContains(response, f'href="{detail_url}"')


### PR DESCRIPTION
## Summary
- implement `BashoListView` and `BashoDetailView`
- register new routes
- render basho pages with new templates
- expose basho links in navigation
- test basho views

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test && coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68546ded84208329804b746dea94a2b5