### PR TITLE
Implement case-insensitive division lookup

### DIFF
--- a/app/views/division.py
+++ b/app/views/division.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.views.generic import DetailView, ListView
 
 from ..models import Division
@@ -14,3 +15,14 @@ class DivisionDetailView(DetailView):
     slug_field = "name"
     slug_url_kwarg = "slug"
     context_object_name = "division"
+
+    def get_object(self, queryset=None):
+        """Return the division matching the URL slug case-insensitively."""
+        queryset = queryset or self.get_queryset()
+        slug = self.kwargs.get(self.slug_url_kwarg)
+        if slug is None:
+            raise Http404("No division specified")
+        try:
+            return queryset.get(name__iexact=slug)
+        except Division.DoesNotExist as exc:
+            raise Http404("Division not found") from exc

--- a/tests/views/test_division_detail.py
+++ b/tests/views/test_division_detail.py
@@ -22,3 +22,8 @@ class DivisionDetailViewTests(TestCase):
             reverse("division-detail", args=[division.name])
         )
         self.assertTemplateUsed(response, "division_detail.html")
+
+    def test_lowercase_slug_returns_page(self):
+        """Using a lowercase slug should still return the page."""
+        response = self.client.get("/division/makuuchi")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- support case-insensitive division slug lookups
- test lower-case slug behaviour

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6854878f97308329ba8d8088221f4fd8