### PR TITLE
Add theme auto-detection

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,9 +8,13 @@
     <link rel="stylesheet" href="{% static 'css/halfmoon.elegant.css' %}">
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/htmx.min.js' %}"></script>
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+    />
     <style>
-        #theme-toggle svg { transition: transform 0.3s; }
-        #theme-toggle.flip svg { transform: rotateY(180deg); }
+        #theme-toggle i { transition: transform 0.3s; }
+        #theme-toggle.flip i { transform: rotateY(180deg); }
     </style>
     {% block extra_head %}{% endblock %}
 </head>
@@ -37,16 +41,12 @@
                     </li>
                 </ul>
                 <button class="btn btn-sm btn-secondary d-flex align-items-center" id="theme-toggle" type="button" aria-label="Toggle theme">
-                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sun" viewBox="0 0 16 16">
-                        <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708" />
-                    </svg>
-                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-moon d-none" viewBox="0 0 16 16">
-                        <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278M4.858 1.311A7.27 7.27 0 0 0 1.025 7.71c0 4.02 3.279 7.276 7.319 7.276a7.32 7.32 0 0 0 5.205-2.162q-.506.063-1.029.063c-4.61 0-8.343-3.714-8.343-8.29 0-1.167.242-2.278.681-3.286" />
-                    </svg>
+                    <i id="icon-sun" class="bi bi-sun"></i>
+                    <i id="icon-moon" class="bi bi-moon d-none"></i>
                 </button>
+                </div>
             </div>
-        </div>
-    </nav>
+        </nav>
     <main class="container">
         {% block content %}{% endblock %}
     </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,10 @@
     <link rel="stylesheet" href="{% static 'css/halfmoon.elegant.css' %}">
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/htmx.min.js' %}"></script>
+    <style>
+        #theme-toggle svg { transition: transform 0.3s; }
+        #theme-toggle.flip svg { transform: rotateY(180deg); }
+    </style>
     {% block extra_head %}{% endblock %}
 </head>
 <body class="with-custom-webkit-scrollbars">
@@ -32,7 +36,14 @@
                         <a class="nav-link" href="{% url 'rikishi-list' %}">Rikishi</a>
                     </li>
                 </ul>
-                <button class="btn btn-sm btn-secondary" id="theme-toggle" type="button">Toggle theme</button>
+                <button class="btn btn-sm btn-secondary d-flex align-items-center" id="theme-toggle" type="button" aria-label="Toggle theme">
+                    <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sun" viewBox="0 0 16 16">
+                        <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708" />
+                    </svg>
+                    <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-moon d-none" viewBox="0 0 16 16">
+                        <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278M4.858 1.311A7.27 7.27 0 0 0 1.025 7.71c0 4.02 3.279 7.276 7.319 7.276a7.32 7.32 0 0 0 5.205-2.162q-.506.063-1.029.063c-4.61 0-8.343-3.714-8.343-8.29 0-1.167.242-2.278.681-3.286" />
+                    </svg>
+                </button>
             </div>
         </div>
     </nav>
@@ -53,10 +64,22 @@
         }
 
         const toggleButton = document.getElementById("theme-toggle");
+        const iconSun = document.getElementById("icon-sun");
+        const iconMoon = document.getElementById("icon-moon");
+
+        function updateIcon() {
+            iconSun.classList.toggle("d-none", html.dataset.bsTheme !== "light");
+            iconMoon.classList.toggle("d-none", html.dataset.bsTheme !== "dark");
+        }
+
+        updateIcon();
+
         toggleButton.addEventListener("click", () => {
             const mode = html.dataset.bsTheme === "dark" ? "light" : "dark";
             html.dataset.bsTheme = mode;
             localStorage.setItem("theme", mode);
+            toggleButton.classList.toggle("flip");
+            updateIcon();
         });
     </script>
 </body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,11 +40,23 @@
         {% block content %}{% endblock %}
     </main>
     <script>
+        const html = document.documentElement;
+        const storedTheme = localStorage.getItem("theme");
+        if (storedTheme === "light" || storedTheme === "dark") {
+            html.dataset.bsTheme = storedTheme;
+        } else if (
+            window.matchMedia("(prefers-color-scheme: dark)").matches
+        ) {
+            html.dataset.bsTheme = "dark";
+        } else {
+            html.dataset.bsTheme = "light";
+        }
+
         const toggleButton = document.getElementById("theme-toggle");
         toggleButton.addEventListener("click", () => {
-            const html = document.documentElement;
             const mode = html.dataset.bsTheme === "dark" ? "light" : "dark";
             html.dataset.bsTheme = mode;
+            localStorage.setItem("theme", mode);
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- detect the user's preferred color scheme on page load
- persist selected theme in local storage
- keep toggle button to switch between light and dark

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6854895161648329bed6c93795a5d4fe