### PR TITLE
Add base Ninja API router

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,9 @@
+from ninja import NinjaAPI
+
+api = NinjaAPI()
+
+
+@api.get("")
+def root(request):
+    """Return a simple confirmation message."""
+    return {"status": "ok"}

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 
+import app.api
+
 urlpatterns = [
     path("", include("app.urls")),
     path("admin/", admin.site.urls),
+    path("api/", app.api.api.urls),
 ]

--- a/tests/config/test_api_route.py
+++ b/tests/config/test_api_route.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+
+class ApiRouteTests(TestCase):
+    """Verify the Ninja API router is mounted."""
+
+    def test_docs_available_at_root(self):
+        response = self.client.get("/api/")
+        self.assertEqual(response.status_code, 200)
+        # docs should still be accessible via /api/docs
+        self.assertEqual(self.client.get("/api/docs").status_code, 200)


### PR DESCRIPTION
## Summary
- set up an empty Ninja API router with a simple root endpoint
- mount the router under `/api/`
- test that the API and docs respond

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68548fdca944832988b4317f7dc3f7a0