### PR TITLE
Add rikishi API endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,4 +1,25 @@
-from ninja import NinjaAPI
+from datetime import date
+from typing import List, Optional
+
+from django.db.models import Q
+from ninja import NinjaAPI, Schema
+
+from .models import Rikishi
+
+
+class RikishiSchema(Schema):
+    """Serialized representation of a ``Rikishi``."""
+
+    id: int
+    name: str
+    name_jp: str
+    heya: Optional[str] = None
+    shusshin: Optional[str] = None
+    rank: Optional[str] = None
+    division: Optional[str] = None
+    international: bool = False
+    intai: Optional[date] = None
+
 
 api = NinjaAPI()
 
@@ -7,3 +28,57 @@ api = NinjaAPI()
 def root(request):
     """Return a simple confirmation message."""
     return {"status": "ok"}
+
+
+def _rikishi_to_schema(rikishi: Rikishi) -> RikishiSchema:
+    """Convert a :class:`Rikishi` instance to :class:`RikishiSchema`."""
+
+    return RikishiSchema(
+        id=rikishi.id,
+        name=rikishi.name,
+        name_jp=rikishi.name_jp,
+        heya=rikishi.heya.name if rikishi.heya else None,
+        shusshin=rikishi.shusshin.name if rikishi.shusshin else None,
+        rank=rikishi.rank.title if rikishi.rank else None,
+        division=rikishi.rank.division.name if rikishi.rank else None,
+        international=(
+            rikishi.shusshin.international if rikishi.shusshin else False
+        ),
+        intai=rikishi.intai,
+    )
+
+
+@api.get("/rikishi/", response=List[RikishiSchema])
+def rikishi_list(
+    request,
+    include_retired: Optional[bool] = None,
+    q: Optional[str] = None,
+    division: Optional[str] = None,
+    heya: Optional[str] = None,
+    international: Optional[bool] = None,
+):
+    """Return a filtered list of rikishi."""
+
+    queryset = Rikishi.objects.all()
+    if include_retired is None:
+        queryset = queryset.filter(intai__isnull=True)
+    if q:
+        queryset = queryset.filter(
+            Q(name__icontains=q) | Q(name_jp__icontains=q)
+        )
+    if heya:
+        queryset = queryset.filter(heya__slug=heya)
+    if division:
+        queryset = queryset.filter(rank__division__name=division)
+    if international is not None:
+        queryset = queryset.filter(shusshin__international=True)
+
+    return [_rikishi_to_schema(r) for r in queryset]
+
+
+@api.get("/rikishi/{rikishi_id}/", response=RikishiSchema)
+def rikishi_detail(request, rikishi_id: int):
+    """Return details for a single rikishi."""
+
+    rikishi = Rikishi.objects.get(pk=rikishi_id)
+    return _rikishi_to_schema(rikishi)

--- a/tests/api/test_rikishi_api.py
+++ b/tests/api/test_rikishi_api.py
@@ -1,0 +1,104 @@
+from datetime import date
+
+from django.test import TestCase
+
+from app.constants import Direction, RankName
+from app.models.division import Division
+from app.models.rank import Rank
+from app.models.rikishi import Heya, Rikishi, Shusshin
+
+
+class RikishiApiTests(TestCase):
+    """Verify the rikishi API endpoints."""
+
+    def setUp(self):
+        self.makuuchi = Division.objects.get(name="Makuuchi")
+        self.juryo = Division.objects.get(name="Juryo")
+
+        self.rank1 = Rank.objects.create(
+            slug="y1e",
+            division=self.makuuchi,
+            title=RankName.YOKOZUNA,
+            order=1,
+            direction=Direction.EAST,
+        )
+        self.rank_j = Rank.objects.create(
+            slug="j1e",
+            division=self.juryo,
+            title=RankName.JURYO,
+            order=1,
+            direction=Direction.EAST,
+        )
+        self.heya1 = Heya.objects.create(name="Miyagino")
+        self.heya2 = Heya.objects.create(name="Isegahama")
+
+        self.shusshin_jp = Shusshin.objects.create(name="Tokyo")
+        self.shusshin_mgl = Shusshin.objects.create(
+            name="Mongolia", international=True
+        )
+
+        Rikishi.objects.create(
+            id=1,
+            name="Hakuho",
+            name_jp="\u767d\u9dc4",
+            heya=self.heya1,
+            rank=self.rank1,
+            shusshin=self.shusshin_jp,
+        )
+        Rikishi.objects.create(
+            id=2,
+            name="Kakuryu",
+            name_jp="\u9db4\u7adc",
+            heya=self.heya2,
+            rank=self.rank_j,
+            shusshin=self.shusshin_mgl,
+        )
+        Rikishi.objects.create(
+            id=3,
+            name="Chiyotaikai",
+            name_jp="\u5343\u4ee3\u5927\u6d77",
+            heya=self.heya1,
+            shusshin=self.shusshin_jp,
+            intai=date(2020, 1, 1),
+        )
+
+    def get_json(self, url):
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def test_list_active_only(self):
+        data = self.get_json("/api/rikishi/")
+        names = [r["name"] for r in data]
+        self.assertEqual(names, ["Hakuho", "Kakuryu"])
+
+    def test_include_retired(self):
+        data = self.get_json("/api/rikishi/?include_retired=1")
+        names = [r["name"] for r in data]
+        self.assertIn("Chiyotaikai", names)
+        self.assertEqual(len(names), 3)
+
+    def test_query_filter(self):
+        data = self.get_json("/api/rikishi/?q=Haku")
+        names = [r["name"] for r in data]
+        self.assertEqual(names, ["Hakuho"])
+
+    def test_heya_filter(self):
+        data = self.get_json(f"/api/rikishi/?heya={self.heya2.slug}")
+        names = [r["name"] for r in data]
+        self.assertEqual(names, ["Kakuryu"])
+
+    def test_division_filter(self):
+        data = self.get_json(f"/api/rikishi/?division={self.makuuchi.name}")
+        names = [r["name"] for r in data]
+        self.assertEqual(names, ["Hakuho"])
+
+    def test_international_filter(self):
+        data = self.get_json("/api/rikishi/?international=1")
+        names = [r["name"] for r in data]
+        self.assertEqual(names, ["Kakuryu"])
+
+    def test_detail_endpoint(self):
+        data = self.get_json("/api/rikishi/1/")
+        self.assertEqual(data["id"], 1)
+        self.assertEqual(data["name"], "Hakuho")


### PR DESCRIPTION
## Summary
- create `RikishiSchema` and helper in `app/api.py`
- add `/api/rikishi/` filterable list endpoint
- add `/api/rikishi/{id}/` detail endpoint
- test list filters and detail retrieval

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68549209d8108329986ffd745978f2fe