### PR TITLE
Add division API endpoints

### DIFF
--- a/tests/api/test_division_api.py
+++ b/tests/api/test_division_api.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from app.models.division import Division
+
+
+class DivisionApiTests(TestCase):
+    """Verify the division API endpoints."""
+
+    def get_json(self, url):
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def test_list_endpoint(self):
+        data = self.get_json("/api/division/")
+        names = [d["name"] for d in data]
+        expected = list(Division.objects.values_list("name", flat=True))
+        self.assertEqual(names, expected)
+
+    def test_detail_endpoint(self):
+        data = self.get_json("/api/division/makuuchi/")
+        self.assertEqual(data["name"], "Makuuchi")
+        self.assertEqual(data["name_short"], "M")
+        self.assertEqual(data["level"], 1)

--- a/tests/api/test_rikishi_api.py
+++ b/tests/api/test_rikishi_api.py
@@ -2,10 +2,10 @@ from datetime import date
 
 from django.test import TestCase
 
-from app.constants import Direction, RankName
 from app.models.division import Division
 from app.models.rank import Rank
 from app.models.rikishi import Heya, Rikishi, Shusshin
+from libs.constants import Direction, RankName
 
 
 class RikishiApiTests(TestCase):


### PR DESCRIPTION
## Summary
- implement DivisionSchema
- add /division/ and /division/{slug}/ routes
- create unit tests for division API
- fix import in rikishi API tests so they run

## Testing
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_685495652d148329a961b3fc37275332