### PR TITLE
Add API pagination

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,6 +1,7 @@
 from .basho import BashoSchema  # noqa: F401
 from .bout import BoutSchema  # noqa: F401
 from .division import DivisionSchema  # noqa: F401
+from .pagination import Paginated  # noqa: F401
 from .rikishi import RikishiSchema  # noqa: F401
 
 __all__ = [
@@ -8,4 +9,5 @@ __all__ = [
     "BoutSchema",
     "DivisionSchema",
     "RikishiSchema",
+    "Paginated",
 ]

--- a/app/schemas/pagination.py
+++ b/app/schemas/pagination.py
@@ -1,0 +1,14 @@
+from typing import Generic, List, TypeVar
+
+from ninja import Schema
+
+T = TypeVar("T")
+
+
+class Paginated(Schema, Generic[T]):
+    """Generic pagination schema."""
+
+    count: int
+    limit: int
+    offset: int
+    items: List[T]

--- a/libs/pagination.py
+++ b/libs/pagination.py
@@ -1,0 +1,34 @@
+from typing import Iterable, Optional
+
+
+class LimitOffsetPaginator:
+    """Simple limit/offset pagination."""
+
+    default_limit = 100
+    max_limit = 1000
+
+    def paginate(
+        self,
+        data: Iterable,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> dict:
+        """Return paginated results as a dictionary."""
+
+        if limit is None:
+            limit = self.default_limit
+        else:
+            limit = min(int(limit), self.max_limit)
+        offset = int(offset or 0)
+        if hasattr(data, "count"):
+            count = data.count()
+        else:
+            data = list(data)
+            count = len(data)
+        items = list(data[offset : offset + limit])
+        return {
+            "count": count,
+            "limit": limit,
+            "offset": offset,
+            "items": items,
+        }

--- a/tests/api/test_basho_api.py
+++ b/tests/api/test_basho_api.py
@@ -15,13 +15,20 @@ class BashoApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         return response.json()
 
+    def get_slugs(self, data):
+        return [b["slug"] for b in data["items"]]
+
     def test_list_endpoint(self):
         data = self.get_json("/api/basho/")
-        slugs = [b["slug"] for b in data]
-        self.assertEqual(slugs, [self.b2.slug, self.b1.slug])
+        self.assertEqual(self.get_slugs(data), [self.b2.slug, self.b1.slug])
 
     def test_detail_endpoint(self):
         data = self.get_json(f"/api/basho/{self.b1.slug}/")
         self.assertEqual(data["slug"], self.b1.slug)
         self.assertEqual(data["year"], 2025)
         self.assertEqual(data["month"], 1)
+
+    def test_limit_offset(self):
+        data = self.get_json("/api/basho/?limit=1&offset=1")
+        self.assertEqual(data["limit"], 1)
+        self.assertEqual(self.get_slugs(data), [self.b1.slug])

--- a/tests/api/test_bout_api.py
+++ b/tests/api/test_bout_api.py
@@ -46,25 +46,39 @@ class BoutApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         return response.json()
 
+    def get_items(self, data):
+        return data["items"]
+
     def test_list_all(self):
         data = self.get_json(f"/api/basho/{self.basho.slug}/bouts/")
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(self.get_items(data)), 2)
 
     def test_division_filter(self):
         data = self.get_json(
             f"/api/basho/{self.basho.slug}/bouts/?division={self.div_m.name}"
         )
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["division"], "Makuuchi")
+        items = self.get_items(data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["division"], "Makuuchi")
 
     def test_day_filter(self):
         data = self.get_json(f"/api/basho/{self.basho.slug}/bouts/?day=2")
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["day"], 2)
+        items = self.get_items(data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["day"], 2)
 
     def test_rikishi_filter(self):
         data = self.get_json(
             f"/api/basho/{self.basho.slug}/bouts/?rikishi_id=1"
         )
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["east"], "A")
+        items = self.get_items(data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["east"], "A")
+
+    def test_limit_offset(self):
+        data = self.get_json(
+            f"/api/basho/{self.basho.slug}/bouts/?limit=1&offset=1"
+        )
+        items = self.get_items(data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["division"], "Juryo")

--- a/tests/api/test_rikishi_api.py
+++ b/tests/api/test_rikishi_api.py
@@ -67,38 +67,42 @@ class RikishiApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         return response.json()
 
+    def get_names(self, data):
+        return [r["name"] for r in data["items"]]
+
     def test_list_active_only(self):
         data = self.get_json("/api/rikishi/")
-        names = [r["name"] for r in data]
-        self.assertEqual(names, ["Hakuho", "Kakuryu"])
+        self.assertEqual(self.get_names(data), ["Hakuho", "Kakuryu"])
 
     def test_include_retired(self):
         data = self.get_json("/api/rikishi/?include_retired=1")
-        names = [r["name"] for r in data]
+        names = self.get_names(data)
         self.assertIn("Chiyotaikai", names)
         self.assertEqual(len(names), 3)
 
     def test_query_filter(self):
         data = self.get_json("/api/rikishi/?q=Haku")
-        names = [r["name"] for r in data]
-        self.assertEqual(names, ["Hakuho"])
+        self.assertEqual(self.get_names(data), ["Hakuho"])
 
     def test_heya_filter(self):
         data = self.get_json(f"/api/rikishi/?heya={self.heya2.slug}")
-        names = [r["name"] for r in data]
-        self.assertEqual(names, ["Kakuryu"])
+        self.assertEqual(self.get_names(data), ["Kakuryu"])
 
     def test_division_filter(self):
         data = self.get_json(f"/api/rikishi/?division={self.makuuchi.name}")
-        names = [r["name"] for r in data]
-        self.assertEqual(names, ["Hakuho"])
+        self.assertEqual(self.get_names(data), ["Hakuho"])
 
     def test_international_filter(self):
         data = self.get_json("/api/rikishi/?international=1")
-        names = [r["name"] for r in data]
-        self.assertEqual(names, ["Kakuryu"])
+        self.assertEqual(self.get_names(data), ["Kakuryu"])
 
     def test_detail_endpoint(self):
         data = self.get_json("/api/rikishi/1/")
         self.assertEqual(data["id"], 1)
         self.assertEqual(data["name"], "Hakuho")
+
+    def test_limit_offset(self):
+        data = self.get_json("/api/rikishi/?limit=1&offset=1")
+        self.assertEqual(data["limit"], 1)
+        self.assertEqual(data["offset"], 1)
+        self.assertEqual(self.get_names(data), ["Kakuryu"])


### PR DESCRIPTION
## Summary
- add simple LimitOffsetPaginator and Paginated schema
- paginate rikishi, basho, and bout routes
- support limit/offset params
- adjust API tests for paginated responses
- move paginator module to `libs`

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68551cbe3a4483298654a160882c1314