### PR TITLE
Handle missing shusshin flag lookup

### DIFF
--- a/app/models/rikishi.py
+++ b/app/models/rikishi.py
@@ -39,9 +39,11 @@ class Shusshin(models.Model):
 
     def flag(self):
         if self.international:
-            return pycountry.countries.lookup(self.name).flag
-        else:
-            return "🇯🇵"
+            try:
+                return pycountry.countries.lookup(self.name).flag
+            except LookupError:
+                return "🏳️"
+        return "🇯🇵"
 
     def __str__(self):
         return f"{self.flag()}{self.name}"

--- a/tests/models/test_extra.py
+++ b/tests/models/test_extra.py
@@ -74,6 +74,10 @@ class ModelUtilityTests(SimpleTestCase):
             self.assertEqual(shusshin.flag(), "🇺🇸")  # Uses lookup flag
             self.assertTrue(str(shusshin).startswith("🇺"))
 
+        with patch("pycountry.countries.lookup") as lookup:
+            lookup.side_effect = LookupError
+            self.assertEqual(shusshin.flag(), "🏳️")
+
         rikishi = Rikishi(name="Hakuho", name_jp="白鵬")
         self.assertEqual(str(rikishi), "Hakuho")  # __str__ uses name
 


### PR DESCRIPTION
## Summary
- handle `LookupError` in `Shusshin.flag`
- test fallback when flag lookup fails

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686400faecd88329bf659b8fa9d8f797