### PR TITLE
Optimize rikishi queries with select_related

### DIFF
--- a/app/routes/rikishi.py
+++ b/app/routes/rikishi.py
@@ -21,7 +21,12 @@ def rikishi_list(
 ):
     """Return a filtered list of rikishi."""
 
-    queryset = Rikishi.objects.all()
+    queryset = Rikishi.objects.select_related(
+        "rank__division",
+        "heya",
+        "shusshin",
+        "rank",
+    )
     if include_retired is None:
         queryset = queryset.filter(intai__isnull=True)
     if q:

--- a/app/views/rikishi.py
+++ b/app/views/rikishi.py
@@ -16,7 +16,11 @@ class RikishiListView(ListView):
         return [self.template_name]
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = (
+            super()
+            .get_queryset()
+            .select_related("rank__division", "heya", "shusshin", "rank")
+        )
         params = self.request.GET
         if params.get("include_retired") is None:
             queryset = queryset.filter(intai__isnull=True)


### PR DESCRIPTION
## Summary
- speed up rikishi lookups by selecting related objects in views and API
- keep existing behaviour verified by tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6864010e96188329939edb66db0a1e2f