### PR TITLE
Use get_object_or_404 in API routes

### DIFF
--- a/app/routes/basho.py
+++ b/app/routes/basho.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from ninja import Router
 
 from app.models import Basho, Bout
@@ -22,7 +23,7 @@ def basho_list(request):
 def basho_detail(request, slug: str):
     """Return details for a single basho."""
 
-    basho = Basho.objects.get(slug=slug)
+    basho = get_object_or_404(Basho, slug=slug)
     return basho_to_schema(basho)
 
 

--- a/app/routes/division.py
+++ b/app/routes/division.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from django.shortcuts import get_object_or_404
 from ninja import Router
 
 from app.models import Division
@@ -21,5 +22,5 @@ def division_list(request):
 def division_detail(request, slug: str):
     """Return details for a single division."""
 
-    division = Division.objects.get(name__iexact=slug)
+    division = get_object_or_404(Division, name__iexact=slug)
     return division_to_schema(division)

--- a/app/routes/rikishi.py
+++ b/app/routes/rikishi.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from ninja import Router
 
 from app.models import Rikishi
@@ -42,5 +43,5 @@ def rikishi_list(
 def rikishi_detail(request, rikishi_id: int):
     """Return details for a single rikishi."""
 
-    rikishi = Rikishi.objects.get(pk=rikishi_id)
+    rikishi = get_object_or_404(Rikishi, pk=rikishi_id)
     return rikishi_to_schema(rikishi)

--- a/tests/api/test_basho_api.py
+++ b/tests/api/test_basho_api.py
@@ -25,3 +25,7 @@ class BashoApiTests(TestCase):
         self.assertEqual(data["slug"], self.b1.slug)
         self.assertEqual(data["year"], 2025)
         self.assertEqual(data["month"], 1)
+
+    def test_detail_not_found(self):
+        response = self.client.get("/api/basho/209901/")
+        self.assertEqual(response.status_code, 404)

--- a/tests/api/test_division_api.py
+++ b/tests/api/test_division_api.py
@@ -22,3 +22,7 @@ class DivisionApiTests(TestCase):
         self.assertEqual(data["name"], "Makuuchi")
         self.assertEqual(data["name_short"], "M")
         self.assertEqual(data["level"], 1)
+
+    def test_detail_not_found(self):
+        response = self.client.get("/api/division/unknown/")
+        self.assertEqual(response.status_code, 404)

--- a/tests/api/test_rikishi_api.py
+++ b/tests/api/test_rikishi_api.py
@@ -102,3 +102,7 @@ class RikishiApiTests(TestCase):
         data = self.get_json("/api/rikishi/1/")
         self.assertEqual(data["id"], 1)
         self.assertEqual(data["name"], "Hakuho")
+
+    def test_detail_not_found(self):
+        response = self.client.get("/api/rikishi/99/")
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Summary
- rely on `get_object_or_404` in rikishi, basho and division routes
- validate 404 responses in API tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6863fe636e788329a1efecf2da2e7925