### PR TITLE
Align Python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- sync Dockerfile with README by switching to Python 3.12

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68644c9ad2788329a7bf7f9438e023dc