### PR TITLE
Optimize bout query in API

### DIFF
--- a/app/routes/basho.py
+++ b/app/routes/basho.py
@@ -36,7 +36,12 @@ def basho_bouts(
 ):
     """Return bouts for a basho with optional filters."""
 
-    queryset = Bout.objects.filter(basho__slug=slug)
+    queryset = Bout.objects.select_related(
+        "division",
+        "east",
+        "west",
+        "winner",
+    ).filter(basho__slug=slug)
     if division:
         queryset = queryset.filter(division__name=division)
     if day is not None:

--- a/tests/api/test_bout_api.py
+++ b/tests/api/test_bout_api.py
@@ -68,3 +68,8 @@ class BoutApiTests(TestCase):
         )
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["east"], "A")
+
+    def test_no_extra_queries(self):
+        """Fetching bouts should use a single optimized query."""
+        with self.assertNumQueries(1):
+            self.get_json(f"/api/basho/{self.basho.slug}/bouts/")


### PR DESCRIPTION
## Summary
- include related fields when fetching basho bouts
- assert only one DB query is executed for the bouts API

## Testing
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6865016e07e083298fa1cab352f06cd7