### PR TITLE
[sumoracle] Add responsive meta tags

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,18 @@
 <html lang="en" data-bs-core="elegant">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+        name="description"
+        content="Sumoracle tracks sumo tournaments and rikishi stats."
+    >
+    <meta property="og:title" content="Sumoracle">
+    <meta
+        property="og:description"
+        content="Sumoracle tracks sumo tournaments and rikishi stats."
+    >
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.build_absolute_uri }}">
     <title>{% block title %}Sumoracle{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'css/halfmoon.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/halfmoon.elegant.css' %}">


### PR DESCRIPTION
## Summary
- add viewport meta tag for responsive design
- include description and Open Graph meta tags

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6865248431f88329bbe6381947b12393