### PR TITLE
[sumoracle] Enable hx-boost navigation

### DIFF
--- a/app/views/rikishi.py
+++ b/app/views/rikishi.py
@@ -11,7 +11,9 @@ class RikishiListView(ListView):
     partial_template_name = "partials/rikishi_rows.html"
 
     def get_template_names(self):
-        if self.request.headers.get("HX-Request"):
+        if self.request.headers.get(
+            "HX-Request"
+        ) and not self.request.headers.get("HX-Boosted"):
             return [self.partial_template_name]
         return [self.template_name]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,7 @@
     </style>
     {% block extra_head %}{% endblock %}
 </head>
-<body class="with-custom-webkit-scrollbars">
+<body class="with-custom-webkit-scrollbars" hx-boost="true">
     <nav class="navbar navbar-expand-lg sticky-top text-bg-primary">
         <div class="container-fluid">
             <a class="navbar-brand" href="{% url 'index' %}">Sumoracle</a>


### PR DESCRIPTION
## Summary
- add `hx-boost="true"` to the `body` tag
- return full templates when links are boosted
- run formatting and tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6865278176348329af1b7a589a94c6b1