### PR TITLE
[sumoracle] Add dataset generator command

### DIFF
--- a/app/management/commands/dataset.py
+++ b/app/management/commands/dataset.py
@@ -1,0 +1,102 @@
+import csv
+from datetime import date
+
+from app.management.commands import AsyncBaseCommand
+from app.models import BashoHistory, BashoRating, Bout
+
+
+class Command(AsyncBaseCommand):
+    """Export bout data as a CSV training dataset."""
+
+    help = "Generate dataset for ML training"
+
+    def add_arguments(self, parser):
+        parser.add_argument("outfile", help="CSV file path")
+
+    async def run(self, outfile, **options):
+        headers = [
+            "basho",
+            "day",
+            "east_id",
+            "west_id",
+            "east_rank",
+            "west_rank",
+            "east_rating",
+            "west_rating",
+            "east_height",
+            "west_height",
+            "east_weight",
+            "west_weight",
+            "east_age",
+            "west_age",
+            "east_win",
+        ]
+        with open(outfile, "w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(headers)
+            qs = Bout.objects.select_related(
+                "basho",
+                "east",
+                "west",
+            ).order_by("basho__year", "basho__month", "day", "match_no")
+            async for bout in qs.aiterator():
+                east_hist = (
+                    await BashoHistory.objects.filter(
+                        rikishi_id=bout.east_id,
+                        basho=bout.basho,
+                    )
+                    .select_related("rank__division")
+                    .afirst()
+                )
+                west_hist = (
+                    await BashoHistory.objects.filter(
+                        rikishi_id=bout.west_id,
+                        basho=bout.basho,
+                    )
+                    .select_related("rank__division")
+                    .afirst()
+                )
+                east_rating = await BashoRating.objects.filter(
+                    rikishi_id=bout.east_id,
+                    basho=bout.basho,
+                ).afirst()
+                west_rating = await BashoRating.objects.filter(
+                    rikishi_id=bout.west_id,
+                    basho=bout.basho,
+                ).afirst()
+                start = bout.basho.start_date or date(
+                    bout.basho.year,
+                    bout.basho.month,
+                    1,
+                )
+                east_age = (
+                    (start - bout.east.birth_date).days / 365.25
+                    if bout.east.birth_date
+                    else None
+                )
+                west_age = (
+                    (start - bout.west.birth_date).days / 365.25
+                    if bout.west.birth_date
+                    else None
+                )
+                writer.writerow(
+                    [
+                        bout.basho.slug,
+                        bout.day,
+                        bout.east_id,
+                        bout.west_id,
+                        east_hist.rank.value if east_hist else "",
+                        west_hist.rank.value if west_hist else "",
+                        east_rating.rating if east_rating else "",
+                        west_rating.rating if west_rating else "",
+                        (east_hist.height or bout.east.height or ""),
+                        (west_hist.height or bout.west.height or ""),
+                        (east_hist.weight or bout.east.weight or ""),
+                        (west_hist.weight or bout.west.weight or ""),
+                        round(east_age, 2) if east_age is not None else "",
+                        round(west_age, 2) if west_age is not None else "",
+                        1 if bout.winner_id == bout.east_id else 0,
+                    ]
+                )
+        msg = self.style.SUCCESS(f"Dataset saved to {outfile}")
+        self.stdout.write(msg)

--- a/tests/commands/test_dataset_command.py
+++ b/tests/commands/test_dataset_command.py
@@ -1,0 +1,96 @@
+import asyncio
+import csv
+import tempfile
+from datetime import date
+
+from django.core.management import call_command
+from django.test import TransactionTestCase
+
+from app.models import (
+    Basho,
+    BashoHistory,
+    BashoRating,
+    Bout,
+    Division,
+    Rank,
+    Rikishi,
+)
+from libs.constants import Direction, RankName
+
+
+class DatasetCommandTests(TransactionTestCase):
+    def setUp(self):
+        division = Division.objects.get(name="Makuuchi")
+        self.rank = Rank.objects.create(
+            slug="m1e",
+            division=division,
+            title=RankName.MAEGASHIRA,
+            order=1,
+            direction=Direction.EAST,
+        )
+        self.basho = Basho.objects.create(
+            year=2025,
+            month=1,
+            start_date=date(2025, 1, 10),
+        )
+        self.r1 = Rikishi.objects.create(id=1, name="A", name_jp="A")
+        self.r2 = Rikishi.objects.create(id=2, name="B", name_jp="B")
+        BashoHistory.objects.create(
+            rikishi=self.r1,
+            basho=self.basho,
+            rank=self.rank,
+            height=180.0,
+            weight=150.0,
+        )
+        BashoHistory.objects.create(
+            rikishi=self.r2,
+            basho=self.basho,
+            rank=self.rank,
+            height=182.0,
+            weight=155.0,
+        )
+        BashoRating.objects.create(
+            rikishi=self.r1,
+            basho=self.basho,
+            rating=1500.0,
+            rd=200.0,
+            vol=0.06,
+        )
+        BashoRating.objects.create(
+            rikishi=self.r2,
+            basho=self.basho,
+            rating=1490.0,
+            rd=210.0,
+            vol=0.06,
+        )
+        Bout.objects.create(
+            basho=self.basho,
+            division=division,
+            day=1,
+            match_no=1,
+            east=self.r1,
+            west=self.r2,
+            east_shikona="A",
+            west_shikona="B",
+            kimarite="yorikiri",
+            winner=self.r1,
+        )
+
+    def test_dataset_file_created(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            call_command("dataset", path)
+        finally:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            loop.close()
+        with open(path) as fh:
+            rows = list(csv.reader(fh))
+        self.assertEqual(rows[0][0], "basho")
+        self.assertEqual(len(rows), 2)
+        data = rows[1]
+        self.assertEqual(int(data[2]), self.r1.id)
+        self.assertEqual(int(data[3]), self.r2.id)
+        self.assertEqual(int(data[-1]), 1)

--- a/tests/commands/test_dataset_command.py
+++ b/tests/commands/test_dataset_command.py
@@ -88,9 +88,9 @@ class DatasetCommandTests(TransactionTestCase):
             loop.close()
         with open(path) as fh:
             rows = list(csv.reader(fh))
-        self.assertEqual(rows[0][0], "basho")
+        self.assertEqual(rows[0][0], "year")
         self.assertEqual(len(rows), 2)
         data = rows[1]
-        self.assertEqual(int(data[2]), self.r1.id)
-        self.assertEqual(int(data[3]), self.r2.id)
+        self.assertEqual(int(data[5]), self.r1.id)
+        self.assertEqual(int(data[6]), self.r2.id)
         self.assertEqual(int(data[-1]), 1)


### PR DESCRIPTION
## Summary
- add async `dataset` management command for creating CSV training data
- test dataset command

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68662bd13a0083298aa79cd2b129e5a5