### PR TITLE
[sumoracle] Enhance index summary view

### DIFF
--- a/app/views/index.py
+++ b/app/views/index.py
@@ -1,5 +1,19 @@
 from django.views.generic import TemplateView
 
+from ..models import Basho, Division, Rikishi
+
 
 class IndexView(TemplateView):
     template_name = "index.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["division_count"] = Division.objects.count()
+        context["rikishi_count"] = Rikishi.objects.filter(
+            intai__isnull=True
+        ).count()
+        context["latest_basho"] = Basho.objects.order_by(
+            "-year",
+            "-month",
+        ).first()
+        return context

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,11 +3,32 @@
 {% block title %}Home{% endblock %}
 
 {% block content %}
-    <h2>Welcome to Sumoracle</h2>
-    <p>Browse divisions and rikishi information.</p>
-    <nav>
-        <ul>
-            <li><a href="{% url 'division-list' %}">Divisions</a></li>
-        </ul>
-    </nav>
+<div class="row row-cols-1 row-cols-md-3 g-3 my-3">
+    <div class="col">
+        <a class="card h-100 text-decoration-none" href="{% url 'division-list' %}">
+            <div class="card-body text-center">
+                <h5 class="card-title">Divisions</h5>
+                <p class="card-text display-6">{{ division_count }}</p>
+            </div>
+        </a>
+    </div>
+    <div class="col">
+        <a class="card h-100 text-decoration-none" href="{% url 'rikishi-list' %}">
+            <div class="card-body text-center">
+                <h5 class="card-title">Active Rikishi</h5>
+                <p class="card-text display-6">{{ rikishi_count }}</p>
+            </div>
+        </a>
+    </div>
+    <div class="col">
+        <a class="card h-100 text-decoration-none" href="{% url 'basho-list' %}">
+            <div class="card-body text-center">
+                <h5 class="card-title">Latest Basho</h5>
+                <p class="card-text display-6">
+                    {% if latest_basho %}{{ latest_basho }}{% else %}None{% endif %}
+                </p>
+            </div>
+        </a>
+    </div>
+</div>
 {% endblock %}

--- a/tests/views/test_index.py
+++ b/tests/views/test_index.py
@@ -1,9 +1,15 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from app.models import Basho, Division, Rikishi
+
 
 class IndexViewTests(TestCase):
     """Verify behaviour of the index view."""
+
+    def setUp(self):
+        Basho.objects.create(year=2025, month=1)
+        Rikishi.objects.create(id=1, name="Test", name_jp="テスト")
 
     def test_view_status_code(self):
         """The index view should return HTTP 200."""
@@ -16,6 +22,15 @@ class IndexViewTests(TestCase):
         self.assertTemplateUsed(response, "index.html")
 
     def test_view_links_to_division_list(self):
-        """The page should provide a link to the divisions list."""
+        """Each card should link to the list views."""
         response = self.client.get(reverse("index"))
         self.assertContains(response, reverse("division-list"))
+        self.assertContains(response, reverse("rikishi-list"))
+        self.assertContains(response, reverse("basho-list"))
+
+    def test_counts_in_context(self):
+        """Summary counts should be rendered on the page."""
+        response = self.client.get(reverse("index"))
+        self.assertContains(response, str(Rikishi.objects.count()))
+        self.assertContains(response, str(Basho.objects.first()))
+        self.assertContains(response, str(Division.objects.count()))


### PR DESCRIPTION
## Summary
- extend `IndexView` with counts for divisions, active rikishi and latest basho
- redesign `index.html` with responsive cards linking to list pages
- verify counts and template usage in tests

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68662c17a1548329a2f91bd21899a6e4