### PR TITLE
[sumoracle] add BMI columns to dataset

### DIFF
--- a/app/management/commands/dataset.py
+++ b/app/management/commands/dataset.py
@@ -30,6 +30,8 @@ class Command(AsyncBaseCommand):
             "west_height",
             "east_weight",
             "west_weight",
+            "east_bmi",
+            "west_bmi",
             "east_age",
             "west_age",
             "east_experience",
@@ -103,6 +105,29 @@ class Command(AsyncBaseCommand):
                     if bout.west.debut
                     else None
                 )
+                east_height = (
+                    east_hist and east_hist.height or bout.east.height or ""
+                )
+                west_height = (
+                    west_hist and west_hist.height or bout.west.height or ""
+                )
+                east_weight = (
+                    east_hist and east_hist.weight or bout.east.weight or ""
+                )
+                west_weight = (
+                    west_hist and west_hist.weight or bout.west.weight or ""
+                )
+                east_bmi = (
+                    round(east_weight / ((east_height / 100) ** 2), 2)
+                    if east_height and east_weight
+                    else ""
+                )
+                west_bmi = (
+                    round(west_weight / ((west_height / 100) ** 2), 2)
+                    if west_height and west_weight
+                    else ""
+                )
+
                 writer.writerow(
                     [
                         bout.basho.year,
@@ -116,30 +141,12 @@ class Command(AsyncBaseCommand):
                         west_hist.rank.value if west_hist else "",
                         east_rating.previous_rating if east_rating else "",
                         west_rating.previous_rating if west_rating else "",
-                        (
-                            east_hist
-                            and east_hist.height
-                            or bout.east.height
-                            or ""
-                        ),
-                        (
-                            west_hist
-                            and west_hist.height
-                            or bout.west.weight
-                            or ""
-                        ),
-                        (
-                            east_hist
-                            and east_hist.weight
-                            or bout.east.weight
-                            or ""
-                        ),
-                        (
-                            west_hist
-                            and west_hist.weight
-                            or bout.west.weight
-                            or ""
-                        ),
+                        east_height,
+                        west_height,
+                        east_weight,
+                        west_weight,
+                        east_bmi,
+                        west_bmi,
                         round(east_age, 2) if east_age is not None else "",
                         round(west_age, 2) if west_age is not None else "",
                         round(east_experience, 2)

--- a/tests/commands/test_dataset_command.py
+++ b/tests/commands/test_dataset_command.py
@@ -129,3 +129,23 @@ class DatasetCommandTests(TransactionTestCase):
         finally:
             asyncio.set_event_loop(asyncio.new_event_loop())
             loop.close()
+
+    def test_bmi_columns(self):
+        """BMI values should be written when height and weight are present."""
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            call_command("dataset", path)
+        finally:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            loop.close()
+        with open(path) as fh:
+            rows = list(csv.reader(fh))
+        headers = rows[0]
+        data = rows[1]
+        east_idx = headers.index("east_bmi")
+        west_idx = headers.index("west_bmi")
+        self.assertEqual(float(data[east_idx]), 46.3)
+        self.assertAlmostEqual(float(data[west_idx]), 46.79, places=2)


### PR DESCRIPTION
## Summary
- extend `dataset` command output with BMI columns
- compute BMI when height and weight are present
- test that BMI columns are written correctly

## Testing
- `ruff check .`
- `isort .`
- `ruff check . --fix`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_68666fa31f8483299ad81a72d36ff021