### PR TITLE
[sumoracle] Maintain east_win column placement

### DIFF
--- a/app/management/commands/dataset.py
+++ b/app/management/commands/dataset.py
@@ -36,6 +36,11 @@ class Command(AsyncBaseCommand):
             "west_age",
             "east_experience",
             "west_experience",
+            "rating_diff",
+            "height_diff",
+            "weight_diff",
+            "age_diff",
+            "experience_diff",
             "east_win",
         ]
         with open(outfile, "w", newline="") as fh:
@@ -134,6 +139,37 @@ class Command(AsyncBaseCommand):
                     else ""
                 )
 
+                rating_diff = (
+                    round(
+                        east_rating.previous_rating
+                        - west_rating.previous_rating,
+                        2,
+                    )
+                    if east_rating and west_rating
+                    else ""
+                )
+                height_diff = (
+                    round(east_height - west_height, 1)
+                    if east_height and west_height
+                    else ""
+                )
+                weight_diff = (
+                    round(east_weight - west_weight, 1)
+                    if east_weight and west_weight
+                    else ""
+                )
+                age_diff = (
+                    round(east_age - west_age, 2)
+                    if east_age is not None and west_age is not None
+                    else ""
+                )
+                experience_diff = (
+                    round(east_experience - west_experience, 2)
+                    if east_experience is not None
+                    and west_experience is not None
+                    else ""
+                )
+
                 writer.writerow(
                     [
                         bout.basho.year,
@@ -161,6 +197,11 @@ class Command(AsyncBaseCommand):
                         round(west_experience, 2)
                         if west_experience is not None
                         else "",
+                        rating_diff,
+                        height_diff,
+                        weight_diff,
+                        age_diff,
+                        experience_diff,
                         1 if bout.winner_id == bout.east_id else 0,
                     ]
                 )

--- a/tests/commands/test_dataset_command.py
+++ b/tests/commands/test_dataset_command.py
@@ -96,9 +96,24 @@ class DatasetCommandTests(TransactionTestCase):
         self.assertEqual(rows[0][0], "year")
         self.assertEqual(len(rows), 2)
         data = rows[1]
-        self.assertEqual(int(data[5]), self.r1.id)
-        self.assertEqual(int(data[6]), self.r2.id)
-        self.assertEqual(int(data[-1]), 1)
+        headers = rows[0]
+        east_idx = headers.index("east_id")
+        west_idx = headers.index("west_id")
+        win_idx = headers.index("east_win")
+        self.assertEqual(int(data[east_idx]), self.r1.id)
+        self.assertEqual(int(data[west_idx]), self.r2.id)
+        self.assertEqual(int(data[win_idx]), 1)
+
+        rating_idx = headers.index("rating_diff")
+        height_idx = headers.index("height_diff")
+        weight_idx = headers.index("weight_diff")
+        age_idx = headers.index("age_diff")
+        exp_idx = headers.index("experience_diff")
+        self.assertEqual(float(data[rating_idx]), 0)
+        self.assertEqual(float(data[height_idx]), -2)
+        self.assertEqual(float(data[weight_idx]), -5)
+        self.assertEqual(data[age_idx], "")
+        self.assertEqual(data[exp_idx], "")
 
     def test_query_count_small(self):
         """Exporting multiple bouts should use only a few queries."""


### PR DESCRIPTION
## Summary
- add diff columns before `east_win`
- keep `east_win` as the last column

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68668670eb8883298fd4a744c9798c6a