### PR TITLE
[sumoracle] add rd and vol columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ See `app/management/commands/` for the concrete implementations.
 ## Dataset generation
 
 Use `manage.py dataset OUTFILE` to write a CSV of bout features. The
-command accepts optional filtering flags to limit the exported rows. After
+command accepts optional filtering flags to limit the exported rows. The
+dataset includes differences such as rank, rating deviation and volatility
+(alongside the underlying ``east_rd``/``west_rd`` and ``east_vol``/``west_vol``
+values) plus BMI to capture advantages between opponents. After
 producing the file you can run `manage.py select_features INFILE OUTFILE` to
 reduce the columns based on ANOVA F-scores. These utilities require
 `scikit-learn` and `pandas` which are provided in `requirements.txt`.

--- a/app/management/commands/dataset.py
+++ b/app/management/commands/dataset.py
@@ -26,6 +26,10 @@ class Command(AsyncBaseCommand):
             "west_rank",
             "east_rating",
             "west_rating",
+            "east_rd",
+            "west_rd",
+            "east_vol",
+            "west_vol",
             "east_height",
             "west_height",
             "east_weight",
@@ -44,6 +48,10 @@ class Command(AsyncBaseCommand):
             "age_diff",
             "experience_diff",
             "record_diff",
+            "rank_diff",
+            "rd_diff",
+            "vol_diff",
+            "bmi_diff",
             "east_win",
         ]
         with open(outfile, "w", newline="") as fh:
@@ -183,6 +191,34 @@ class Command(AsyncBaseCommand):
                     else ""
                 )
                 record_diff = east_record - west_record
+                rank_diff = (
+                    east_hist.rank.value - west_hist.rank.value
+                    if east_hist and west_hist
+                    else ""
+                )
+                east_rd = east_rating.previous_rd if east_rating else ""
+                west_rd = west_rating.previous_rd if west_rating else ""
+                rd_diff = (
+                    round(east_rd - west_rd, 2)
+                    if east_rating and west_rating
+                    else ""
+                )
+                east_vol = (
+                    round(east_rating.previous_vol, 5) if east_rating else ""
+                )
+                west_vol = (
+                    round(west_rating.previous_vol, 5) if west_rating else ""
+                )
+                vol_diff = (
+                    round(east_vol - west_vol, 5)
+                    if east_rating and west_rating
+                    else ""
+                )
+                bmi_diff = (
+                    round(east_bmi - west_bmi, 2)
+                    if east_bmi and west_bmi
+                    else ""
+                )
 
                 writer.writerow(
                     [
@@ -197,6 +233,10 @@ class Command(AsyncBaseCommand):
                         west_hist.rank.value if west_hist else "",
                         east_rating.previous_rating if east_rating else "",
                         west_rating.previous_rating if west_rating else "",
+                        east_rd,
+                        west_rd,
+                        east_vol,
+                        west_vol,
                         east_height,
                         west_height,
                         east_weight,
@@ -219,6 +259,10 @@ class Command(AsyncBaseCommand):
                         age_diff,
                         experience_diff,
                         record_diff,
+                        rank_diff,
+                        rd_diff,
+                        vol_diff,
+                        bmi_diff,
                         1 if bout.winner_id == bout.east_id else 0,
                     ]
                 )

--- a/tests/commands/test_dataset_command.py
+++ b/tests/commands/test_dataset_command.py
@@ -109,11 +109,27 @@ class DatasetCommandTests(TransactionTestCase):
         weight_idx = headers.index("weight_diff")
         age_idx = headers.index("age_diff")
         exp_idx = headers.index("experience_diff")
+        rank_idx = headers.index("rank_diff")
+        rd_idx = headers.index("rd_diff")
+        vol_idx = headers.index("vol_diff")
+        east_rd_idx = headers.index("east_rd")
+        west_rd_idx = headers.index("west_rd")
+        east_vol_idx = headers.index("east_vol")
+        west_vol_idx = headers.index("west_vol")
+        bmi_idx = headers.index("bmi_diff")
         self.assertEqual(float(data[rating_idx]), 0)
         self.assertEqual(float(data[height_idx]), -2)
         self.assertEqual(float(data[weight_idx]), -5)
         self.assertEqual(data[age_idx], "")
         self.assertEqual(data[exp_idx], "")
+        self.assertEqual(float(data[rank_idx]), 0)
+        self.assertEqual(float(data[rd_idx]), 0)
+        self.assertEqual(float(data[vol_idx]), 0)
+        self.assertEqual(float(data[east_rd_idx]), 350)
+        self.assertEqual(float(data[west_rd_idx]), 350)
+        self.assertAlmostEqual(float(data[east_vol_idx]), 0.11, places=2)
+        self.assertAlmostEqual(float(data[west_vol_idx]), 0.11, places=2)
+        self.assertAlmostEqual(float(data[bmi_idx]), -0.49, places=2)
 
     def test_query_count_small(self):
         """Exporting multiple bouts should use only a few queries."""
@@ -162,8 +178,10 @@ class DatasetCommandTests(TransactionTestCase):
         data = rows[1]
         east_idx = headers.index("east_bmi")
         west_idx = headers.index("west_bmi")
+        diff_idx = headers.index("bmi_diff")
         self.assertEqual(float(data[east_idx]), 46.3)
         self.assertAlmostEqual(float(data[west_idx]), 46.79, places=2)
+        self.assertAlmostEqual(float(data[diff_idx]), -0.49, places=2)
 
     def test_head_to_head_records(self):
         prev = Basho.objects.create(
@@ -241,6 +259,12 @@ class DatasetCommandTests(TransactionTestCase):
         self.assertEqual(target[headers.index("east_height")], "")
         self.assertEqual(target[headers.index("west_weight")], "")
         self.assertEqual(target[headers.index("height_diff")], "")
+        self.assertEqual(target[headers.index("rank_diff")], "")
+        self.assertEqual(target[headers.index("east_rd")], "")
+        self.assertEqual(target[headers.index("west_rd")], "")
+        self.assertEqual(target[headers.index("east_vol")], "")
+        self.assertEqual(target[headers.index("west_vol")], "")
+        self.assertEqual(target[headers.index("bmi_diff")], "")
 
     def test_missing_rating(self):
         """Rows should handle bouts missing ``BashoRating`` entries."""
@@ -289,3 +313,9 @@ class DatasetCommandTests(TransactionTestCase):
         self.assertEqual(target[headers.index("east_rating")], "")
         self.assertEqual(target[headers.index("west_rating")], "")
         self.assertEqual(target[headers.index("rating_diff")], "")
+        self.assertEqual(target[headers.index("rd_diff")], "")
+        self.assertEqual(target[headers.index("vol_diff")], "")
+        self.assertEqual(target[headers.index("east_rd")], "")
+        self.assertEqual(target[headers.index("west_rd")], "")
+        self.assertEqual(target[headers.index("east_vol")], "")
+        self.assertEqual(target[headers.index("west_vol")], "")


### PR DESCRIPTION
## Summary
- extend dataset export with rating deviation and volatility
- compute rd_diff, vol_diff and bmi_diff
- add tests for rd/vol columns
- document new dataset fields

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_686c482294308329806195e7f7d4f6e5