### PR TITLE
[sumoracle] Add Prediction model

### DIFF
--- a/app/migrations/0013_prediction.py
+++ b/app/migrations/0013_prediction.py
@@ -1,0 +1,67 @@
+import django.db.models.deletion
+from django.core import validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0012_rename_app_bashora_rikishi_e02e83_idx_app_bashora_rikishi_811c00_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Prediction",
+            fields=[
+                (
+                    "pk",
+                    models.CompositePrimaryKey(
+                        "rikishi_id",
+                        "basho_id",
+                        blank=True,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "wins",
+                    models.FloatField(
+                        validators=[
+                            validators.MinValueValidator(0.0),
+                            validators.MaxValueValidator(15.0),
+                        ]
+                    ),
+                ),
+                (
+                    "basho",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="predictions",
+                        to="app.basho",
+                    ),
+                ),
+                (
+                    "rikishi",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="predictions",
+                        to="app.rikishi",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name_plural": "Predictions",
+                "ordering": ["basho__year", "basho__month", "rikishi_id"],
+                "indexes": [
+                    models.Index(fields=["rikishi", "basho"], name="app_predic_rikishi_basho_idx"),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("rikishi", "basho"),
+                        name="unique_rikishi_prediction",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from .basho import Basho  # noqa: F401
 from .bout import Bout  # noqa: F401
 from .division import Division  # noqa: F401
 from .history import BashoHistory  # noqa: F401
+from .prediction import Prediction  # noqa: F401
 from .rank import Rank  # noqa: F401
 from .rating import BashoRating  # noqa: F401
 from .rikishi import Heya, Rikishi, Shusshin  # noqa: F401

--- a/app/models/prediction.py
+++ b/app/models/prediction.py
@@ -1,0 +1,37 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+
+from .basho import Basho
+from .rikishi import Rikishi
+
+
+class Prediction(models.Model):
+    """Predicted wins for a rikishi in a future ``Basho``."""
+
+    pk = models.CompositePrimaryKey("rikishi_id", "basho_id")
+    rikishi = models.ForeignKey(
+        Rikishi,
+        on_delete=models.CASCADE,
+        related_name="predictions",
+    )
+    basho = models.ForeignKey(
+        Basho,
+        on_delete=models.CASCADE,
+        related_name="predictions",
+    )
+    wins = models.FloatField(
+        validators=[MinValueValidator(0.0), MaxValueValidator(15.0)]
+    )
+
+    class Meta:
+        ordering = ["basho__year", "basho__month", "rikishi_id"]
+        verbose_name_plural = "Predictions"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["rikishi", "basho"], name="unique_rikishi_prediction"
+            )
+        ]
+        indexes = [models.Index(fields=["rikishi", "basho"])]
+
+    def __str__(self):
+        return f"{self.rikishi_id} {self.basho_id}: {self.wins}"

--- a/tests/models/test_prediction.py
+++ b/tests/models/test_prediction.py
@@ -1,0 +1,34 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from app.models import Basho, Prediction, Rikishi
+
+
+class PredictionModelTests(TestCase):
+    """Tests for the ``Prediction`` model."""
+
+    def setUp(self):
+        self.rikishi = Rikishi.objects.create(id=1, name="A", name_jp="A")
+        self.basho = Basho.objects.create(year=2025, month=1)
+
+    def test_prediction_creation(self):
+        """Predictions should store the wins value."""
+        p = Prediction.objects.create(
+            rikishi=self.rikishi,
+            basho=self.basho,
+            wins=10.5,
+        )
+        self.assertEqual(p.wins, 10.5)
+
+    def test_wins_validation(self):
+        """Wins outside 0-15 should raise a validation error."""
+        bad = Prediction(
+            rikishi=self.rikishi,
+            basho=self.basho,
+            wins=16,
+        )
+        with self.assertRaises(ValidationError):
+            bad.full_clean()
+        bad.wins = -1
+        with self.assertRaises(ValidationError):
+            bad.full_clean()


### PR DESCRIPTION
## Summary
- add `Prediction` model for storing expected wins
- create migration
- expose `Prediction` via models package
- test prediction creation and validation

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_686ff1dada308329a8420e0a32f77109