### PR TITLE
[sumoracle] Add neural network prediction command

### DIFF
--- a/app/management/commands/nn_predict.py
+++ b/app/management/commands/nn_predict.py
@@ -1,0 +1,115 @@
+import random
+from itertools import combinations
+
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import StandardScaler
+
+from app.models import Basho, BashoHistory, BashoRating, Prediction, Rikishi
+
+
+class Command(BaseCommand):
+    help = "Train NN from dataset and predict next basho"
+
+    def add_arguments(self, parser):
+        parser.add_argument("dataset", help="CSV training dataset")
+        parser.add_argument("--iterations", type=int, default=1000)
+
+    def handle(self, dataset, iterations, *args, **options):
+        df = pd.read_csv(dataset)
+        required = ["rating_diff", "rank_diff", "rd_diff", "east_win"]
+        if not all(col in df.columns for col in required):
+            raise CommandError("Dataset missing required columns")
+        df = df.dropna(subset=required)
+        X = df[["rating_diff", "rank_diff", "rd_diff"]].astype(float)
+        y = df["east_win"].astype(int)
+
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(X)
+
+        model = MLPClassifier(
+            hidden_layer_sizes=(10,), max_iter=200, random_state=42
+        )
+        model.fit(X_scaled, y)
+
+        next_basho = (
+            Basho.objects.filter(bouts__isnull=True)
+            .order_by("-year", "-month")
+            .first()
+        )
+        if not next_basho:
+            self.stdout.write("No upcoming basho found")
+            return
+
+        rikishi = list(
+            Rikishi.objects.filter(
+                intai__isnull=True, rank__division__name="Makuuchi"
+            ).select_related("rank", "heya")
+        )
+        if not rikishi:
+            self.stdout.write("No rikishi found")
+            return
+
+        ratings = {
+            r.id: BashoRating.objects.filter(rikishi=r)
+            .order_by("-basho__year", "-basho__month")
+            .first()
+            for r in rikishi
+        }
+        histories = {
+            r.id: BashoHistory.objects.filter(
+                rikishi=r, basho=next_basho
+            ).first()
+            for r in rikishi
+        }
+
+        probs = {}
+        for r1, r2 in combinations(rikishi, 2):
+            if r1.heya_id and r1.heya_id == r2.heya_id:
+                continue
+            rating1 = ratings.get(r1.id)
+            rating2 = ratings.get(r2.id)
+            history1 = histories.get(r1.id)
+            history2 = histories.get(r2.id)
+            if not rating1 or not rating2 or not history1 or not history2:
+                p = 0.5
+            else:
+                feat = [
+                    rating1.rating - rating2.rating,
+                    history1.rank.value - history2.rank.value,
+                    rating1.rd - rating2.rd,
+                ]
+                feat = scaler.transform([feat])
+                p = float(model.predict_proba(feat)[0, 1])
+            probs.setdefault(r1.id, {})[r2.id] = p
+            probs.setdefault(r2.id, {})[r1.id] = 1 - p
+
+        records = {r.id: {"wins": 0, "total": 0, "obj": r} for r in rikishi}
+
+        pairs = [
+            (r1, r2)
+            for r1, r2 in combinations(rikishi, 2)
+            if not (r1.heya_id and r1.heya_id == r2.heya_id)
+        ]
+
+        for _ in range(iterations):
+            for r1, r2 in pairs:
+                p = probs[r1.id][r2.id]
+                winner = r1 if random.random() < p else r2
+                records[winner.id]["wins"] += 1
+                records[r1.id]["total"] += 1
+                records[r2.id]["total"] += 1
+
+        for rec in records.values():
+            total = rec["total"]
+            win_rate = rec["wins"] / total if total else 0
+            rec["pred_wins"] = win_rate * 15
+            Prediction.objects.update_or_create(
+                rikishi=rec["obj"],
+                basho=next_basho,
+                defaults={"wins": rec["pred_wins"]},
+            )
+            self.stdout.write(
+                f"{rec['obj'].name: <12} {rec['pred_wins']:.2f} wins"
+            )

--- a/tests/commands/test_nn_predict_command.py
+++ b/tests/commands/test_nn_predict_command.py
@@ -74,11 +74,12 @@ class NNPredictCommandTests(TestCase):
                 "weight_diff",
                 "age_diff",
                 "experience_diff",
+                "record_diff",
                 "east_win",
             ]
         )
-        writer.writerow([10, 0, 0, 0, 0, 0, 0, 1])
-        writer.writerow([-10, 0, 0, 0, 0, 0, 0, 0])
+        writer.writerow([10, 0, 0, 0, 0, 0, 0, 0, 1])
+        writer.writerow([-10, 0, 0, 0, 0, 0, 0, 0, 0])
         self.dataset.close()
 
     def tearDown(self):

--- a/tests/commands/test_nn_predict_command.py
+++ b/tests/commands/test_nn_predict_command.py
@@ -65,9 +65,20 @@ class NNPredictCommandTests(TestCase):
         )
         self.dataset = tempfile.NamedTemporaryFile("w", delete=False)
         writer = csv.writer(self.dataset)
-        writer.writerow(["rating_diff", "rank_diff", "rd_diff", "east_win"])
-        writer.writerow([10, 0, 0, 1])
-        writer.writerow([-10, 0, 0, 0])
+        writer.writerow(
+            [
+                "rating_diff",
+                "rank_diff",
+                "rd_diff",
+                "height_diff",
+                "weight_diff",
+                "age_diff",
+                "experience_diff",
+                "east_win",
+            ]
+        )
+        writer.writerow([10, 0, 0, 0, 0, 0, 0, 1])
+        writer.writerow([-10, 0, 0, 0, 0, 0, 0, 0])
         self.dataset.close()
 
     def tearDown(self):

--- a/tests/commands/test_nn_predict_command.py
+++ b/tests/commands/test_nn_predict_command.py
@@ -1,0 +1,85 @@
+import csv
+import os
+import tempfile
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from app.models import (
+    Basho,
+    BashoHistory,
+    BashoRating,
+    Division,
+    Prediction,
+    Rank,
+    Rikishi,
+)
+from libs.constants import Direction, RankName
+
+
+class NNPredictCommandTests(TestCase):
+    def setUp(self):
+        self.division, _ = Division.objects.get_or_create(
+            name="Makuuchi", defaults={"name_short": "M", "level": 1}
+        )
+        self.rank = Rank.objects.create(
+            slug="m1e",
+            division=self.division,
+            title=RankName.MAEGASHIRA,
+            order=1,
+            direction=Direction.EAST,
+        )
+        self.b1 = Basho.objects.create(year=2025, month=1)
+        self.b2 = Basho.objects.create(year=2025, month=3)
+        self.r1 = Rikishi.objects.create(
+            id=1, name="A", name_jp="A", rank=self.rank
+        )
+        self.r2 = Rikishi.objects.create(
+            id=2, name="B", name_jp="B", rank=self.rank
+        )
+        BashoHistory.objects.create(
+            rikishi=self.r1, basho=self.b1, rank=self.rank
+        )
+        BashoHistory.objects.create(
+            rikishi=self.r2, basho=self.b1, rank=self.rank
+        )
+        BashoHistory.objects.create(
+            rikishi=self.r1, basho=self.b2, rank=self.rank
+        )
+        BashoHistory.objects.create(
+            rikishi=self.r2, basho=self.b2, rank=self.rank
+        )
+        BashoRating.objects.create(
+            rikishi=self.r1,
+            basho=self.b1,
+            rating=1510.0,
+            rd=200.0,
+            vol=0.06,
+        )
+        BashoRating.objects.create(
+            rikishi=self.r2,
+            basho=self.b1,
+            rating=1500.0,
+            rd=200.0,
+            vol=0.06,
+        )
+        self.dataset = tempfile.NamedTemporaryFile("w", delete=False)
+        writer = csv.writer(self.dataset)
+        writer.writerow(["rating_diff", "rank_diff", "rd_diff", "east_win"])
+        writer.writerow([10, 0, 0, 1])
+        writer.writerow([-10, 0, 0, 0])
+        self.dataset.close()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.dataset.name)
+        except OSError:
+            pass
+
+    def test_predictions_saved(self):
+        call_command("nn_predict", self.dataset.name, "--iterations", "10")
+        preds = Prediction.objects.filter(basho=self.b2)
+        self.assertEqual(preds.count(), 2)
+        for p in preds:
+            self.assertGreaterEqual(p.wins, 0)
+            self.assertLessEqual(p.wins, 15)


### PR DESCRIPTION
## Summary
- add `nn_predict` command to train MLPClassifier on bout dataset
- simulate upcoming basho results and store predictions
- test neural network prediction command

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_686ff6f183bc8329a6ab2386254bd9e6