### PR TITLE
[sumoracle] Add CV option to nn_predict

### DIFF
--- a/app/management/commands/nn_predict.py
+++ b/app/management/commands/nn_predict.py
@@ -64,12 +64,19 @@ class Command(BaseCommand):
             grid = GridSearchCV(
                 pipe,
                 {
-                    "clf__hidden_layer_sizes": [(10,), (20,)],
-                    "clf__alpha": [0.0001, 0.001],
-                    "clf__max_iter": [200, 400],
+                    "clf__hidden_layer_sizes": [
+                        (32, 16),
+                        (64, 32, 16),
+                    ],
+                    "clf__alpha": [0.0001, 0.001, 0.01],
+                    "clf__learning_rate": ["constant"],
+                    "clf__max_iter": [200, 400, 1000],
+                    # early stopping to avoid needless epochs
+                    "clf__early_stopping": [True],
+                    "clf__validation_fraction": [0.1],
                 },
                 cv=cv,
-                n_jobs=1,
+                n_jobs=-1,
             )
             grid.fit(X, y)
             self.stdout.write(


### PR DESCRIPTION
## Summary
- add `--cv` flag to `nn_predict` command
- use `GridSearchCV` to tune MLP parameters
- print best params and score when CV is enabled
- mock GridSearchCV in tests to keep them fast
- add unit test for the CV option

## Testing
- `ruff check .`
- `isort .`
- `ruff check --fix .`
- `ruff format .`
- `coverage run manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6870431c85888329a589a6ded6d713c7